### PR TITLE
Adds title to video iframe to improve accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
       var ml_account = ml("accounts", "3172990", "d6u7p8a8b7", "load");
     </script>
     <!-- End MailerLite Universal -->
-    <style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style>    
+    <style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style>
   </head>
   <body>
     <svg class="background-wave--header" xmlns="http://www.w3.org/2000/svg">
@@ -202,9 +202,9 @@
 
           <div class="video">
             <div class='embed-container'>
-              <iframe src='https://www.youtube.com/embed/59Y9lgYyQYo' frameborder='0' allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+              <iframe title="The Green Software Foundation Intro" src='https://www.youtube.com/embed/59Y9lgYyQYo' frameborder='0' allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
               </iframe>
-            </div>  
+            </div>
           </div>
 
         </article>
@@ -456,7 +456,7 @@
                 Board Representative | Chief of Staff to the COO at GitHub
               </h5></a
             >
-          </div>            
+          </div>
           <div
             style="background-image: url(assets/team/Dan-Lewis-Toakley-min.jpeg)"
           >
@@ -484,7 +484,7 @@
                 Board Representative | Associate Director, Technology Sustainability Innovation at Accenture
               </h5></a
             >
-          </div>        
+          </div>
           <div
             style="background-image: url(assets/team/Patrick-Chanezon-min.jpeg)"
           >
@@ -508,7 +508,7 @@
           representing academia, for-profits and non-profits all sharing a
           mission to grow the field of Green Software Engineering. The
           Foundation is a neutral space managed by the Linux Foundation and
-          designed to enable collaboration. 
+          designed to enable collaboration.
         </p>
         <p>Currently we are only accepting
           membership through an organization, non-profit or for-profit. Please
@@ -549,8 +549,8 @@
         d="M0,160L80,176C160,192,320,224,480,218.7C640,213,800,171,960,160C1120,149,1280,171,1360,181.3L1440,192L1440,320L1360,320C1280,320,1120,320,960,320C800,320,640,320,480,320C320,320,160,320,80,320L0,320Z"
       ></path>
     </svg>
-    
-    <footer>    
+
+    <footer>
       <div class="footer--body">
         <p>Copyright © 2021 Joint Development Foundation Projects, LLC, Green Software Foundation Series</p>
       </div>
@@ -563,7 +563,7 @@
                 href="/"
                 >Home</a
               >
-            </li>            
+            </li>
             <li>
               <a
                 target="_blank"
@@ -580,13 +580,13 @@
                 title="Terms of Use, Privacy Policy and Cookie Policy."
                 href="/terms.html"
               >Terms of Use, Privacy Policy and Cookie Policy.</a>
-            </li>     
+            </li>
           </ul>
         </nav>
       </div>
       <div class="footer--body">
         <p>The Joint Development Foundation Projects, LLC is an affiliate of the Linux Foundation.</p>
-      </div>      
+      </div>
     </footer>
 
     <style>


### PR DESCRIPTION
After updating the video to use a YouTube iframe, it seems Accessibility score on lighthouse dropped from 100 to 97, because the iFrame didn't have a title attribute. 

![Green_Software_Foundation](https://user-images.githubusercontent.com/2144730/119896205-b3ae7600-bf0c-11eb-9401-a142f0f8ec27.png)

This pull request adds a title attribute to the iFrame element, with the same title as the video on YouTube.

It looks like my IDE also removed some unnecessary whitespace. If this is a problem, I'd be happy to revert that and re-push the title update, isolated :) 