### PR TITLE
Adjust disclaimer panel text and styling

### DIFF
--- a/src/pages/onboarding.js
+++ b/src/pages/onboarding.js
@@ -58,7 +58,7 @@ const OnboardingPage = ({
         register with the Foundation.
         <br />
         <br />
-        Registering:-
+        Registering:
         <ul>
           <li>
             Gives you access to member only spaces, emails and communication

--- a/src/pages/subscribe.js
+++ b/src/pages/subscribe.js
@@ -82,7 +82,8 @@ const SubscribePage = ({
           </li>
         </ul>
         Prior to using this form you must have completed the{" "}
-        <Link to="/onboarding"> registration form </Link> and received a
+        <Link to="/onboarding">registration form</Link>{" "}
+        and received a
         confirmation email.
         <br />
         <br />

--- a/src/pages/subscribe.js
+++ b/src/pages/subscribe.js
@@ -63,11 +63,11 @@ const SubscribePage = ({
     >
       <PageTitle>Subscription Form</PageTitle>
       <Disclaimer>
-        <strong>Employees of member organizations</strong> an use this form to
+        <strong>Employees of member organizations</strong> can use this form to
         subscribe to specific working groups and projects.
         <br />
         <br />
-        Subscribing:-
+        Subscribing:
         <ul>
           <li>
             Adds you to any mailing lists for the working groups or projects.

--- a/src/styles/components/disclaimer.scss
+++ b/src/styles/components/disclaimer.scss
@@ -6,7 +6,6 @@
   border: 1px solid var(--accent1);
   color: var(--accent1-darker);
   font-size: 0.875rem;
-  text-align: center;
   .icon {
     color: var(--accent1-dark);
     margin-bottom: 1rem;
@@ -22,7 +21,6 @@
     display: grid;
     grid-template-rows: 32px 1fr;
     gap: 1.5rem;
-    text-align: left;
     max-width: 640px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
Hello 🙂 This PR adjusts texts and styling in the disclaimer panel.

- Fix a typo
- Remove two (assumingly) unnecessary `-` characters and spaces in anchor text.
- Avoid centering text style in the disclaimer panel.
  - This is because it was causing an unclean layout on the small screen.
  - The style change affects three panels but shouldn't hurt the readability.

## Screenshots
### Before
![Screenshot from 2023-11-27 21-12-54](https://github.com/Green-Software-Foundation/greensoftware.foundation/assets/1425259/312b0f2d-2726-4940-9254-4dbc2951b8b8)


### After
![Screenshot from 2023-11-27 17-45-11](https://github.com/Green-Software-Foundation/greensoftware.foundation/assets/1425259/4cff1095-4212-4ee4-b130-5542ae9537d2)

