### PR TITLE
update: rename 'Join the GSF' button to 'Membership Form' on membership page

### DIFF
--- a/src/pages/membership.astro
+++ b/src/pages/membership.astro
@@ -31,7 +31,7 @@ const resolveOrgs = (names: string[]) => names.map(name => ({ name, logoSrc: log
     navItems={navItems}
     ctaText="Discuss your challenges"
     ctaHref="mailto:help@greensoftware.foundation?subject=Membership%20enquiry"
-    secondaryCtaText="Join the GSF"
+    secondaryCtaText="Membership Form"
     secondaryCtaHref="https://enrollment.lfx.linuxfoundation.org?project=green-software-foundation-fund"
   />
 
@@ -414,7 +414,7 @@ const resolveOrgs = (names: string[]) => names.map(name => ({ name, logoSrc: log
           rel="noopener noreferrer"
           class="inline-flex items-center justify-center rounded-lg border border-primary bg-white px-8 py-3 text-base font-bold text-primary transition-colors hover:bg-accent-lightest-2"
         >
-          Join the GSF
+          Membership Form
         </a>
         <p class="text-xs text-gray-darker">
           Not sure which tier is right for you?{" "}

--- a/src/pages/membership.astro
+++ b/src/pages/membership.astro
@@ -448,7 +448,7 @@ const resolveOrgs = (names: string[]) => names.map(name => ({ name, logoSrc: log
       rel="noopener noreferrer"
       class="flex items-center gap-2 rounded-lg border border-primary bg-white px-5 py-2.5 text-sm font-bold text-primary shadow-md transition-colors hover:bg-accent-lightest-2"
     >
-      Join the GSF
+      Membership Form
     </a>
   </div>
 </Layout>


### PR DESCRIPTION
Updates the button label from "Join the GSF" to "Membership Form" in all three locations on the membership page: navbar CTA, below the fees table, and the floating button.

https://claude.ai/code/session_01WKwpSusJ2b9gQ4ZRf9i3KB