### PR TITLE
Add academic membership landing page

### DIFF
--- a/docs/pages/membership-academic.md
+++ b/docs/pages/membership-academic.md
@@ -18,7 +18,7 @@ All content on this page is hardcoded:
 - **Hero** — eyebrow badge, headline "Where Research Becomes Standard", 3-paragraph body, two CTAs (primary → `#submission-form`, secondary → `/governance/`)
 - **The Convening Model** — heading, two body paragraphs, 4-step numbered list with preamble, governance disclaimer
 - **What Our Members Are Working On** — 5 research challenge cards with icons and closing line
-- **Forms of Engagement** — 6 bullet items describing how institutions can engage
+- **Forms of Engagement** — 6 cards in a numbered grid (3-column on desktop, 2-column on tablet) describing how institutions can engage
 - **Standards — Active Research Areas** — 4 standard items (SCI, SCI for AI, SCI for Web, SOFT) with research needs; SCI links to `https://sci.greensoftware.foundation/`
 - **Academic Membership** — heading, body, 4 benefit items, membership note, current member text list (8 universities), closing line
 - **Submission Form** — anchor `#submission-form`, 6 form fields (4 required, 2 optional), client-side confirmation UX (no backend endpoint), privacy note

--- a/docs/pages/membership-academic.md
+++ b/docs/pages/membership-academic.md
@@ -1,49 +1,50 @@
-# Academic Membership Page
+# Academic & Research Engagement Page
 
 **URL:** `/membership/academic/`
 **File:** `src/pages/membership/academic/index.astro`
 
 ## What it shows
 
-A dedicated landing page for academic institutions explaining the GSF academic membership programme. Academic (and non-profit/government) membership is free. The page covers what GSF is working on, what membership enables, maps research disciplines to active projects, lists current academic member universities, and provides an enquiry pathway.
+A landing page for academic and research institutions explaining how they can engage with and join the Green Software Foundation. Targets Vice-Chancellors, Provosts, Directors of Research, and Heads of Department. The page presents the GSF convening model, active research challenges from member organisations, forms of engagement, standards with open research needs, academic membership benefits, and a proposal submission form.
 
 ## Dynamic elements
 
-| Element | Source | Notes |
-|---|---|---|
-| Steering member logos | `src/data/members.json` via `LogoMarquee` | Fetched from Notion via `npm run fetch-notion` |
+None. All content is static and hardcoded (see below for update guidance).
 
 ## Static elements
 
-All other content on this page is hardcoded static copy — this is intentional:
+All content on this page is hardcoded:
 
-- **Hero** — pitch text, CTA to `/membership/enquire/`
-- **What the Foundation is working on** — 5 domain feature cards
-- **What academic membership enables** — 8 benefit feature cards
-- **Discipline mapping table** — 9 research disciplines mapped to GSF projects
-- **Universities currently participating** — list of 17 academic member institutions (verified March 2026)
-- **Relevance to institutional sustainability objectives** — body copy
-- **Complementary academic programmes** — 4 resource cards (SE4GD, GREENER, ARCHER2, Texas State)
-- **How to enquire** — 4-step bordered feature grid
-- **FAQ** — 5 Q&As using native `<details>/<summary>` accordion
-- **Final CTA** — links to `/membership/enquire/`
+- **Hero** — eyebrow badge, headline "Where Research Becomes Standard", 3-paragraph body, two CTAs (primary → `#submission-form`, secondary → `/governance/`)
+- **The Convening Model** — heading, two body paragraphs, 4-step numbered list with preamble, governance disclaimer
+- **What Our Members Are Working On** — 5 research challenge cards with icons and closing line
+- **Forms of Engagement** — 6 bullet items describing how institutions can engage
+- **Standards — Active Research Areas** — 4 standard items (SCI, SCI for AI, SCI for Web, SOFT) with research needs; SCI links to `https://sci.greensoftware.foundation/`
+- **Academic Membership** — heading, body, 4 benefit items, membership note, current member text list (8 universities), closing line
+- **Submission Form** — anchor `#submission-form`, 6 form fields (4 required, 2 optional), client-side confirmation UX (no backend endpoint), privacy note
 
 ## How to update
 
-### Adding a new university
-Find the universities array in the "Universities currently participating" section (appears twice — once for desktop table, once for mobile cards). Add the institution to both arrays in alphabetical or logical order. Update the heading count and the "Verified against..." footnote date.
+### Adding or removing a "Working On" card
+Edit the `workingOnCards` array in the frontmatter. Each item has `title`, `description`, and `icon` (path to a `/assets/` SVG).
 
-### Updating discipline mappings
-Find the rows array in the "Discipline mapping table" section (appears twice — desktop and mobile). Edit the relevant `discipline` and `work` fields.
+### Updating the Standards section
+Edit the `standardsItems` array. Items may have an optional `link` and `linkText` for a "view standard" link below the description.
 
-### Updating the enquiry contact
-Search for `jamie.cowan@greensoftware.foundation` and update the name and email in the "How to enquire" FeatureGrid.
+### Adding a benefit to Academic Membership
+Edit `membershipBenefits` in the frontmatter. Items render as `**title** — body`.
 
-### Adding/editing FAQ items
-Find the FAQ `<details>` section and edit the `q` and `a` fields in the items array.
+### Updating the current academic members list
+Find the `Current academic members:` line in Section 6 and edit the `·`-separated list of institution names.
 
-### Changing the CTA destination
-The primary CTA links to `/membership/enquire/`. This appears in three places: the Hero `ctas` prop, the "How to enquire" section, and the final `CTABanner`.
+### Updating the Convening Model text or disclaimer
+Edit the text directly in Section 2 of the template (the custom `<section>` block).
+
+### Updating the Forms of Engagement list
+Edit the `engagementForms` array in the frontmatter.
+
+### Wiring up the submission form backend
+The form currently prevents the default submit, hides itself, and shows an inline confirmation message. The `<script>` tag at the bottom of the file handles this. To add a real backend, update the `form.addEventListener("submit", ...)` handler to POST the form data before showing the confirmation.
 
 ## Navigation
 

--- a/docs/pages/membership-academic.md
+++ b/docs/pages/membership-academic.md
@@ -16,9 +16,9 @@ None. All content is static and hardcoded (see below for update guidance).
 All content on this page is hardcoded:
 
 - **Hero** — eyebrow badge, headline "Where Research Becomes Standard", 3-paragraph body, two CTAs (primary → `#submission-form`, secondary → `/governance/`)
-- **The Convening Model** — heading, two body paragraphs, 4-step numbered list with preamble, governance disclaimer
-- **What Our Members Are Working On** — 5 research challenge cards with icons and closing line
-- **Forms of Engagement** — 6 cards in a numbered grid (3-column on desktop, 2-column on tablet) describing how institutions can engage
+- **The Convening Model** — "How It Works" badge, extrabold heading with accent, two intro paragraphs in a 2-column cream card layout, 4-step vertical pipeline, bordered disclaimer callout
+- **Forms of Engagement** — 6 cards (3-column on desktop) describing how institutions can engage; each has a button with an external link
+- **What Our Members Are Working On** — 6 cards (5 research challenges + 1 "Your Research" CTA card); followed by a full-width Testimonial quote attributed to the GSF Chairperson
 - **Standards — Active Research Areas** — 4 standard items (SCI, SCI for AI, SCI for Web, SOFT) with research needs; SCI links to `https://sci.greensoftware.foundation/`
 - **Academic Membership** — heading, body, 4 benefit items, membership note, current member text list (8 universities), closing line
 - **Submission Form** — anchor `#submission-form`, 6 form fields (4 required, 2 optional), client-side confirmation UX (no backend endpoint), privacy note
@@ -38,7 +38,10 @@ Edit `membershipBenefits` in the frontmatter. Items render as `**title** — bod
 Find the `Current academic members:` line in Section 6 and edit the `·`-separated list of institution names.
 
 ### Updating the Convening Model text or disclaimer
-Edit the text directly in Section 2 of the template (the custom `<section>` block).
+Edit the text directly in Section 2 of the template. The two intro paragraphs are in the two-column card grid. The numbered steps are an inline `.map()` array — edit the strings there. The disclaimer is in the `border-l-4` callout box below the steps.
+
+### Updating the closing quote on What Our Members Are Working On
+Edit the `<Testimonial />` component props after the "What Our Members Are Working On" section. Update `quote`, `author`, `title`, and `company` as needed.
 
 ### Updating the Forms of Engagement list
 Edit the `engagementForms` array in the frontmatter.

--- a/docs/pages/membership-academic.md
+++ b/docs/pages/membership-academic.md
@@ -20,7 +20,8 @@ All content on this page is hardcoded:
 - **Forms of Engagement** — 6 cards (3-column on desktop) describing how institutions can engage; each has a button with an external link
 - **What Our Members Are Working On** — 6 cards (5 research challenges + 1 "Your Research" CTA card); followed by a full-width Testimonial quote attributed to the GSF Chairperson
 - **Standards — Active Research Areas** — 4 standard items (SCI, SCI for AI, SCI for Web, SOFT) with research needs; SCI links to `https://sci.greensoftware.foundation/`
-- **Academic Membership** — heading, body, 4 benefit items, membership note, current member text list (8 universities), closing line
+- **Academic Membership** — eyebrow badge, heading with accent, intro paragraph, 4 benefit cards (each with checkmark icon, bold title, and body text), green callout box ("Available at no cost") with CTA, closing line
+- **Academic member logos marquee** — scrolling logo marquee filtered to `organisationType === "Academia"` from `src/data/members.json`. Falls back to a static text list of 8 university names if no academic logos are available (e.g. during local dev without Notion data).
 - **Submission Form** — anchor `#submission-form`, 6 form fields (4 required, 2 optional), client-side confirmation UX (no backend endpoint), privacy note
 
 ## How to update
@@ -32,10 +33,13 @@ Edit the `workingOnCards` array in the frontmatter. Each item has `title`, `desc
 Edit the `standardsItems` array. Items may have an optional `link` and `linkText` for a "view standard" link below the description.
 
 ### Adding a benefit to Academic Membership
-Edit `membershipBenefits` in the frontmatter. Items render as `**title** — body`.
+Edit `membershipBenefits` in the frontmatter. Each item has `title`, `body`, and `icon` (unused in the current layout — checkmark icons are rendered inline). Items render as a card with a green checkmark, bold title, and body paragraph.
 
-### Updating the current academic members list
-Find the `Current academic members:` line in Section 6 and edit the `·`-separated list of institution names.
+### Updating the academic member logos
+Academic member logos are fetched from Notion (`Members` DB, `Organisation Type = Academia`) at build time. To add or update a logo, update the member's entry in Notion — the logo downloads automatically on the next `npm run build:full`. The marquee uses `LogoMarquee` with a pre-filtered `logos` prop.
+
+### Updating the fallback university list
+If academic logos are unavailable (e.g. during local dev), a static text list is shown. Edit the `·`-separated list in the fallback `<section>` inside the `{academicLogos.length > 0 ? ... : ...}` conditional.
 
 ### Updating the Convening Model text or disclaimer
 Edit the text directly in Section 2 of the template. The two intro paragraphs are in the two-column card grid. The numbered steps are an inline `.map()` array — edit the strings there. The disclaimer is in the `border-l-4` callout box below the steps.

--- a/docs/pages/membership-academic.md
+++ b/docs/pages/membership-academic.md
@@ -1,0 +1,50 @@
+# Academic Membership Page
+
+**URL:** `/membership/academic/`
+**File:** `src/pages/membership/academic/index.astro`
+
+## What it shows
+
+A dedicated landing page for academic institutions explaining the GSF academic membership programme. Academic (and non-profit/government) membership is free. The page covers what GSF is working on, what membership enables, maps research disciplines to active projects, lists current academic member universities, and provides an enquiry pathway.
+
+## Dynamic elements
+
+| Element | Source | Notes |
+|---|---|---|
+| Steering member logos | `src/data/members.json` via `LogoMarquee` | Fetched from Notion via `npm run fetch-notion` |
+
+## Static elements
+
+All other content on this page is hardcoded static copy — this is intentional:
+
+- **Hero** — pitch text, CTA to `/membership/enquire/`
+- **What the Foundation is working on** — 5 domain feature cards
+- **What academic membership enables** — 8 benefit feature cards
+- **Discipline mapping table** — 9 research disciplines mapped to GSF projects
+- **Universities currently participating** — list of 17 academic member institutions (verified March 2026)
+- **Relevance to institutional sustainability objectives** — body copy
+- **Complementary academic programmes** — 4 resource cards (SE4GD, GREENER, ARCHER2, Texas State)
+- **How to enquire** — 4-step bordered feature grid
+- **FAQ** — 5 Q&As using native `<details>/<summary>` accordion
+- **Final CTA** — links to `/membership/enquire/`
+
+## How to update
+
+### Adding a new university
+Find the universities array in the "Universities currently participating" section (appears twice — once for desktop table, once for mobile cards). Add the institution to both arrays in alphabetical or logical order. Update the heading count and the "Verified against..." footnote date.
+
+### Updating discipline mappings
+Find the rows array in the "Discipline mapping table" section (appears twice — desktop and mobile). Edit the relevant `discipline` and `work` fields.
+
+### Updating the enquiry contact
+Search for `jamie.cowan@greensoftware.foundation` and update the name and email in the "How to enquire" FeatureGrid.
+
+### Adding/editing FAQ items
+Find the FAQ `<details>` section and edit the `q` and `a` fields in the items array.
+
+### Changing the CTA destination
+The primary CTA links to `/membership/enquire/`. This appears in three places: the Hero `ctas` prop, the "How to enquire" section, and the final `CTABanner`.
+
+## Navigation
+
+This page is linked from the site nav under **About → For Members → Academic Membership** (`src/lib/nav-items.ts`).

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -303,7 +303,7 @@ export const navItems = [
           {
             href: "/membership/academic/",
             label: "Academic Membership",
-            description: "Free membership for universities and research institutions",
+            description: "Collaborate with GSF Members",
           },
           {
             href: "https://wiki.greensoftware.foundation/getting-started",

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -301,6 +301,11 @@ export const navItems = [
             description: "Step-by-step guide to the enrolment process",
           },
           {
+            href: "/membership/academic/",
+            label: "Academic Membership",
+            description: "Collaborate with GSF Members",
+          },
+          {
             href: "https://wiki.greensoftware.foundation/getting-started",
             label: "Getting Started",
             /* icon: "book-open", */ external: true,

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -301,6 +301,11 @@ export const navItems = [
             description: "Step-by-step guide to the enrolment process",
           },
           {
+            href: "/membership/academic/",
+            label: "Academic Membership",
+            description: "Free membership for universities and research institutions",
+          },
+          {
             href: "https://wiki.greensoftware.foundation/getting-started",
             label: "Getting Started",
             /* icon: "book-open", */ external: true,

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -301,11 +301,6 @@ export const navItems = [
             description: "Step-by-step guide to the enrolment process",
           },
           {
-            href: "/membership/academic/",
-            label: "Academic Membership",
-            description: "Collaborate with GSF Members",
-          },
-          {
             href: "https://wiki.greensoftware.foundation/getting-started",
             label: "Getting Started",
             /* icon: "book-open", */ external: true,

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -742,10 +742,11 @@ const membershipBenefits = [
             <div class="h-px flex-1 bg-white/20"></div>
           </div>
 
-          <!-- Co-chairs: featured, larger cards -->
+          <!-- Co-chairs: featured, horizontal layout (logo left, text right) -->
           <div class="mb-3 grid gap-3 sm:grid-cols-2">
             {committeeWithLogos.filter((m) => m.role === "Co-Chair").map((member) => (
-              <div class="flex flex-col items-center gap-3 rounded-xl bg-white p-5 text-center">
+              <div class="relative flex items-center gap-4 rounded-xl bg-white p-5">
+                <span class="absolute right-3 top-3 rounded-full bg-accent px-2.5 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
                 <div class="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-xl p-1">
                   {member.logo ? (
                     <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
@@ -753,8 +754,7 @@ const membershipBenefits = [
                     <span class="text-xl font-extrabold text-primary">{member.initials}</span>
                   )}
                 </div>
-                <div>
-                  <span class="mb-1 inline-block rounded-full bg-accent px-2.5 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
+                <div class="min-w-0 pr-14">
                   <p class="text-sm font-extrabold leading-tight text-primary-dark">{member.name}</p>
                   <p class="mt-0.5 text-xs text-gray-darker">{member.org}</p>
                 </div>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -236,6 +236,8 @@ const crossCuttingAreas = [
     title: "Hardware–Software Interoperability for Data Centre Sustainability",
     description:
       "Sitting at the intersection of hardware efficiency standards and operational data centre practice, this assembly addresses a critical gap: hardware-level efficiency metrics and software-level workload decisions are currently optimised in isolation. The goal is a shared framework that enables data centre operators to align workload scheduling with real-time energy and cooling constraints.",
+    link: "/assemblies/hardware-software-interoperability-for-data-centre-sustainability/",
+    linkText: "Register your interest in the assembly",
   },
 ];
 
@@ -526,21 +528,9 @@ const membershipBenefits = [
           ))}
         </div>
 
-        <div class="mt-10 rounded-2xl bg-white p-6 shadow-sm md:p-8">
-          <div class="flex gap-4">
-            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
-              <svg class="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-              </svg>
-            </div>
-            <div>
-              <p class="text-sm font-bold text-primary-dark">A transparent, collective process</p>
-              <p class="mt-2 text-sm leading-relaxed text-gray-darker">
-                There is no guaranteed outcome from submission. Every substantive proposal receives a considered review — and decisions are made collectively by the Policy Working Group, not by a single point of contact. The process has genuine governance integrity.
-              </p>
-            </div>
-          </div>
-        </div>
+        <p class="mt-8 text-xs leading-relaxed text-gray-darker/70 italic">
+          There is no guaranteed outcome from submission. Every substantive proposal receives a considered review — decisions are made collectively by the Policy Working Group, not by a single point of contact. The process has genuine governance integrity.
+        </p>
       </div>
     </div>
   </section>
@@ -591,6 +581,15 @@ const membershipBenefits = [
       </div>
     </div>
   </section>
+
+  <!-- Full member logo marquee -->
+  <LogoMarquee
+    heading="GSF member organisations"
+    bgClass="bg-accent-lightest-2"
+    fadeBgClass="from-accent-lightest-2"
+    directoryHref="https://directory.greensoftware.foundation/members/"
+    directoryText="View all members"
+  />
 
   <Testimonial
     quote="If your institution is active in any of these areas, use the submission form below. Our members' problem statements evolve as the field develops. This list is not exhaustive, and we welcome suggestions."
@@ -657,10 +656,10 @@ const membershipBenefits = [
         </div>
       </div>
 
-      <!-- Cross-Cutting Research Areas -->
+      <!-- Future Research via GSF Assemblies -->
       <div class="mt-10">
         <div class="mb-6 flex items-center gap-4">
-          <h3 class="shrink-0 text-base font-extrabold uppercase tracking-wide text-primary-dark">Cross-Cutting Research Areas</h3>
+          <h3 class="shrink-0 text-base font-extrabold uppercase tracking-wide text-primary-dark">Future Research via GSF Assemblies Powered by the Harmony Tool</h3>
           <div class="h-px flex-1 bg-accent-lighter"></div>
         </div>
         <p class="mb-6 text-sm text-gray-darker">Active initiatives feeding into the standards pipeline — where academic collaboration is being actively sought.</p>
@@ -684,71 +683,70 @@ const membershipBenefits = [
   <!-- Green AI Committee full-width section -->
   <section class="bg-primary py-16 md:py-20">
     <div class="container">
-      <!-- Centred header -->
-      <div class="text-center">
-        <p class="mb-4 text-xs font-bold uppercase tracking-widest text-accent">GSF Committee</p>
+      <!-- Header -->
+      <div class="mb-10">
+        <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">GSF Committee</p>
         <h2 class="text-2xl font-extrabold text-white md:text-3xl lg:text-4xl">Green AI Committee</h2>
       </div>
 
-      <!-- Two-column cards — one paragraph each, clearly labelled -->
-      <div class="mx-auto mt-10 grid max-w-5xl gap-5 md:grid-cols-2">
-        <div class="rounded-2xl bg-white/10 p-6 md:p-8">
-          <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">Policy &amp; Standards</p>
-          <p class="text-base leading-relaxed text-white/90">
-            The Green AI Committee is GSF's dedicated policy and standards body responding to EU AI Act obligations — and was an active contributor to the SCI for AI ratification process. It coordinates GSF's collective technical response to AI environmental regulation across member organisations, translating industry deployment realities into policy positions that regulators can act on.
-          </p>
-        </div>
-        <div class="rounded-2xl bg-white/10 p-6 md:p-8">
-          <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">For Academic Researchers</p>
-          <p class="text-base leading-relaxed text-white/90">
-            For academic researchers working at the intersection of AI, environmental assessment, and regulatory compliance, the Green AI Committee is the point of engagement — connecting academic expertise directly to the policy and standards processes where it carries weight.
-          </p>
-        </div>
-      </div>
-
-      <!-- CTAs centred -->
-      <div class="mt-8 flex flex-wrap justify-center gap-4">
-        <a
-          href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
-          class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
-        >
-          EU AI Act analysis →
-        </a>
-        <a
-          href="#submission-form"
-          class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
-        >
-          Express your interest →
-        </a>
-      </div>
-
-      <!-- Committee Members — unified grid -->
-      <div class="mx-auto mt-14 max-w-5xl">
-        <div class="mb-8 flex items-center gap-4">
-          <p class="shrink-0 text-xs font-bold uppercase tracking-widest text-white/50">Committee Members</p>
-          <div class="h-px flex-1 bg-white/20"></div>
+      <!-- Left-right layout: text left, members right -->
+      <div class="grid gap-10 lg:grid-cols-2 lg:gap-14">
+        <!-- Left: text boxes + CTAs -->
+        <div class="flex flex-col gap-5">
+          <div class="rounded-2xl bg-white/10 p-6">
+            <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">Policy &amp; Standards</p>
+            <p class="text-base leading-relaxed text-white/90">
+              The Green AI Committee is GSF's dedicated policy and standards body responding to EU AI Act obligations — and was an active contributor to the SCI for AI ratification process. It coordinates GSF's collective technical response to AI environmental regulation across member organisations, translating industry deployment realities into policy positions that regulators can act on.
+            </p>
+          </div>
+          <div class="rounded-2xl bg-white/10 p-6">
+            <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">For Academic Researchers</p>
+            <p class="text-base leading-relaxed text-white/90">
+              For academic researchers working at the intersection of AI, environmental assessment, and regulatory compliance, the Green AI Committee is the point of engagement — connecting academic expertise directly to the policy and standards processes where it carries weight.
+            </p>
+          </div>
+          <div class="flex flex-wrap gap-3 pt-2">
+            <a
+              href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
+              class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
+            >
+              EU AI Act analysis →
+            </a>
+            <a
+              href="#submission-form"
+              class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
+            >
+              Express your interest →
+            </a>
+          </div>
         </div>
 
-        <!-- All members in a single 4-column grid; co-chairs distinguished by badge -->
-        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {committeeWithLogos.map((member) => (
-            <div class="flex items-center gap-4 rounded-xl bg-white p-4">
-              <div class="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-accent-lightest-2 p-2">
-                {member.logo ? (
-                  <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
-                ) : (
-                  <span class="text-lg font-extrabold text-primary">{member.initials}</span>
-                )}
+        <!-- Right: Committee members grid -->
+        <div>
+          <div class="mb-5 flex items-center gap-4">
+            <p class="shrink-0 text-xs font-bold uppercase tracking-widest text-white/50">Committee Members</p>
+            <div class="h-px flex-1 bg-white/20"></div>
+          </div>
+          <div class="grid gap-3 sm:grid-cols-2">
+            {committeeWithLogos.map((member) => (
+              <div class="flex items-center gap-3 rounded-xl bg-white p-4">
+                <div class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-accent-lightest-2 p-1.5">
+                  {member.logo ? (
+                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
+                  ) : (
+                    <span class="text-base font-extrabold text-primary">{member.initials}</span>
+                  )}
+                </div>
+                <div class="min-w-0">
+                  <p class="text-sm font-extrabold leading-tight text-primary-dark">{member.name}</p>
+                  <p class="mt-0.5 truncate text-xs text-gray-darker">{member.org}</p>
+                  {member.role === "Co-Chair" && (
+                    <span class="mt-1 inline-block rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
+                  )}
+                </div>
               </div>
-              <div class="min-w-0">
-                <p class="text-sm font-extrabold leading-tight text-primary-dark">{member.name}</p>
-                <p class="mt-0.5 truncate text-xs text-gray-darker">{member.org}</p>
-                {member.role === "Co-Chair" && (
-                  <span class="mt-1.5 inline-block rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
-                )}
-              </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </div>
     </div>
@@ -757,7 +755,15 @@ const membershipBenefits = [
   <!-- Section 5b: Active GSF Policy Engagements -->
   <section class="bg-white py-16 md:py-20">
     <div class="container">
-      <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Active GSF Policy Engagements</h2>
+      <div class="flex flex-wrap items-baseline gap-4">
+        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Active GSF Policy Engagements</h2>
+        <a
+          href="https://greensoftware.foundation/policy/"
+          class="inline-flex items-center text-sm font-semibold text-primary hover:underline"
+        >
+          About our policy work →
+        </a>
+      </div>
       <p class="mt-4 max-w-2xl text-base text-primary-dark md:text-lg">
         GSF participates directly in regulatory consultations and policy formation. Academic researchers working in these areas can contribute formal expertise via GSF membership.
       </p>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -18,7 +18,7 @@ const academicLogos = (membersData as any[])
     website: m.companyWebsite || "greensoftware.foundation",
   }));
 
-const heroBody = "If your institution is working on software sustainability, AI energy footprint, or digital environmental methodology — there are GSF members actively looking for what you are already building.";
+const heroBody = `If your institution is working on software sustainability, AI energy footprint, or digital environmental methodology — there are <strong class="font-extrabold text-primary">GSF members actively looking for what you are building</strong>. Submit your proposal for consideration.`;
 
 const workingOnCards = [
   {

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -4,18 +4,122 @@ import { navItems } from "@/lib/nav-items";
 
 import Navbar from "@/components/navbar.astro";
 import Hero from "@/components/hero.astro";
-import LogoMarquee from "@/components/logo-marquee.astro";
-import TextBlock from "@/components/text-block.astro";
-import TextWithImage from "@/components/text-with-image.astro";
-import FeatureGrid from "@/components/feature-grid.astro";
-import ResourceCards from "@/components/resource-cards.astro";
-import CTABanner from "@/components/cta-banner.astro";
 import Footer from "@/components/footer.astro";
+
+const heroBody = [
+  "The Green Software Foundation is where a computer science department's measurement methodology research connects directly to the ESG reporting reality of a Fortune 500 company implementing it next quarter. No other organisation holds both sides of that relationship simultaneously.",
+  "GSF convenes the industry members who need answers and the research institutions who develop them — and provides the governance infrastructure to turn that collaboration into ratified, ISO-certified standards.",
+  "If your institution is working on software sustainability, AI energy footprint, or digital environmental methodology — there are GSF members actively looking for what you are already building.",
+].join("<br><br>");
+
+const workingOnCards = [
+  {
+    title: "AI Workload Carbon Quantification",
+    description:
+      "Measuring the full lifecycle footprint of AI systems across training, inference, and end-of-life. Direct input into the SCI for AI standard, ratified December 2025.",
+    icon: "/assets/realtime-icon.svg",
+  },
+  {
+    title: "Carbon-Aware Scheduling Methodology",
+    description:
+      "Optimising when and where software workloads run based on grid carbon intensity. A UCL carbon-aware scheduler project, presented to the GSF Steering Committee in April 2026, demonstrated 44–56% carbon savings through temporal and spatial scheduling.",
+    icon: "/assets/co2-icon.svg",
+  },
+  {
+    title: "SCI Methodology Validation",
+    description:
+      "Independent academic validation of Software Carbon Intensity measurement approaches under CSRD Scope 3 reporting requirements carries regulatory and procurement weight that industry-produced documentation does not.",
+    icon: "/assets/standardized-icon.svg",
+  },
+  {
+    title: "Data Centre Water & Energy Baseline Standards",
+    description:
+      "Establishing defensible measurement baselines for water consumption and energy use across hyperscale and edge infrastructure.",
+    icon: "/assets/shape-icon-1.svg",
+  },
+  {
+    title: "SCI for Web",
+    description:
+      "Extending Software Carbon Intensity methodology to web-based systems. An early-stage specification where academic input into design foundations is directly relevant.",
+    icon: "/assets/shape-icon-2.svg",
+  },
+];
+
+const engagementForms = [
+  {
+    title: "Co-authorship",
+    body: "on white papers and technical guidance aligned with GSF standards — research that reaches the organisations implementing it, not only those reading it.",
+  },
+  {
+    title: "Assembly participation",
+    body: "via GSF's Harmony platform — the AI-facilitated consensus mechanism through which standards are shaped from blank-page problem statement to ratified specification; academic voices participate in the process, not just the output.",
+  },
+  {
+    title: "Structured introductions",
+    body: "to specific GSF member organisations where a research project aligns with an active member challenge — subject to Policy Working Group review and approval.",
+  },
+  {
+    title: "Named researcher recognition",
+    body: "in GSF publications and communications — providing evidence of real-world impact, a publication route, and a named industry partner.",
+  },
+  {
+    title: "Hackathon & event participation",
+    body: ", including the annual Carbon Hack, providing applied research opportunities with direct industry involvement.",
+  },
+  {
+    title: "Formal academic membership",
+    body: "— available at no cost — as the collaboration matures and alignment with GSF's mission is established.",
+  },
+];
+
+const standardsItems = [
+  {
+    title: "SCI Standard — ISO/IEC 21031:2024",
+    description:
+      "The only ISO-certified metric for software carbon. Active research need: independent methodology validation; domain extension to emerging system types; implementation benchmarking across sectors.",
+    link: "https://sci.greensoftware.foundation/",
+    linkText: "View the SCI standard →",
+  },
+  {
+    title: "SCI for AI — ratified December 2025",
+    description:
+      "The first consensus-based standard for measuring AI carbon footprint across six lifecycle stages. Active research need: training vs. inference carbon apportionment; embodied carbon in AI hardware; long-running workload optimisation. A UCL team's carbon-aware scheduler work — presented to the GSF Steering Committee in April 2026 — demonstrates the level of applied academic engagement the Foundation actively supports.",
+  },
+  {
+    title: "SCI for Web — in active development",
+    description:
+      "Extending SCI methodology to web-based software. Active research need: design foundations for the specification; measurement methodology for client-side and CDN carbon. Academic input is directly relevant at this early stage.",
+  },
+  {
+    title: "SOFT Framework — ratified November 2025",
+    description:
+      "The first ratified standard for embedding green software practices across an entire organisation. Active research need: implementation case studies; compliance pathway analysis under CSRD; sector-specific adaptation frameworks.",
+  },
+];
+
+const membershipBenefits = [
+  {
+    title: "Named industry partnerships",
+    body: "structured connections to GSF member organisations working on adjacent challenges, providing the industry-linked research context that EU Horizon, UKRI, and NSF funding applications increasingly require.",
+  },
+  {
+    title: "Publication routes",
+    body: "co-authorship credit on GSF technical reports, reviewed by the relevant Assembly and released publicly; a route to work that is read by the organisations deploying it, not only the academics citing it.",
+  },
+  {
+    title: "Evidence of real-world impact",
+    body: "GSF standards are ISO-certified and in active deployment across banking, technology, and infrastructure; research that contributes to them produces the impact evidence that determines career progression and institutional research rankings.",
+  },
+  {
+    title: "Peer network access",
+    body: "participation in working groups, Assemblies, and GSF events alongside the member organisations deploying green software at scale.",
+  },
+];
 ---
 
 <Layout
-  title="Academic Membership — Green Software Foundation"
-  description="Free membership for universities and research institutions. Join 17 academic partners shaping international standards for sustainable software and hardware."
+  title="Academic & Research Engagement — Green Software Foundation"
+  description="The Green Software Foundation connects academic research in software sustainability directly to the Fortune 500 organisations implementing it. Free membership for qualifying institutions."
 >
   <Navbar
     logoSrc="/assets/gsf-logo-full.svg"
@@ -28,423 +132,283 @@ import Footer from "@/components/footer.astro";
 
   <!-- Section 1: Hero -->
   <Hero
-    heading="Academic membership in the"
-    headingAccent="Green Software Foundation"
-    body="The Green Software Foundation develops international standards for sustainable software and hardware. Academic membership gives your researchers direct access to the consensus process, the working groups, and the global network of organisations building them."
+    badge="Green Software Foundation · Academic & Research Engagement"
+    heading="Where Research"
+    headingAccent="Becomes Standard"
+    body={heroBody}
     ctas={[
-      { text: "Enquire about academic membership", variant: "primary", href: "/membership/enquire/" },
+      { text: "Submit a Proposal", variant: "primary", href: "#submission-form" },
+      { text: "View our membership governance →", variant: "outline", href: "/governance/" },
     ]}
     imageSrc="/assets/hero-illustration.svg"
-    imageAlt="Academic membership illustration"
+    imageAlt="Academic & Research Engagement illustration"
     bgClass="bg-accent-lightest-2"
   />
 
-  <!-- Section 2: Member logos — credibility -->
-  <LogoMarquee
-    heading="Our members include Microsoft, Google, Accenture, UBS, Goldman Sachs, Siemens, IBM, Cisco, NTT DATA, and over 60 other organisations — alongside 17 universities already participating"
-    greyscale={false}
-    bgClass="bg-white"
-    fadeBgClass="from-white"
-  />
-
-  <!-- Section 3: What the Foundation is working on -->
-  <TextBlock
-    heading="What the Foundation is *working on*"
-    body="Our active portfolio spans five domains. Each is governed by a dedicated Working Group or Committee, open to participation from all member organisations — including academic institutions."
-    compact
-  />
-
-  <FeatureGrid
-    columns={3}
-    features={[
-      {
-        icon: "/assets/standardized-icon.svg",
-        title: "Software Standards",
-        description: "Specifications that enable organisations to quantify and reduce the environmental impact of their software. Includes SCI (ISO/IEC 21031:2024), SCI for AI (ratified Dec 2025), SCI for Web, SEE, SWE, Carmen, SCI Guide, RTC, SOFT, SCI Self Certification, and SCI for Games.",
-      },
-      {
-        icon: "/assets/co2-icon.svg",
-        title: "Hardware Standards",
-        description: "Specifications addressing the full lifecycle of physical infrastructure — manufacturing, operation, and end-of-life. Active work: WDPC (Approved), Open19 (Published). In development: SCI for Circularity, where expertise in materials science and lifecycle assessment is particularly relevant.",
-      },
-      {
-        icon: "/assets/realtime-icon.svg",
-        title: "AI & Energy Efficiency",
-        description: "AI energy consumption is projected to more than quadruple by 2030. The Green AI Committee coordinates standards and educational work: SCI for AI across six lifecycle stages, the Green AI Practitioner Course (in proposal), and regulatory analysis of the EU AI Act and AI Environmental Impacts Act.",
-      },
-      {
-        icon: "/assets/shape-icon-3.svg",
-        title: "Policy & Regulation",
-        description: "The Policy Working Group tracks emerging legislation, produces position papers, and ensures GSF standards inform regulatory frameworks. Output includes the Policy Radar, CSRD Scope 3 compliance guidance, EU AI Act analysis, and the State of Green Software Report.",
-      },
-      {
-        icon: "/assets/renewable-icon.svg",
-        title: "Education, Tooling & Adoption",
-        description: "The Developer Relations Committee maintains open-source tools and educational resources. Includes the Green Software Practitioner Course (130,000+ completions), Green Software Patterns, Awesome Green Software, Carbon Aware SDK (deployed in production banking at UBS), and the Impact Framework.",
-      },
-    ]}
-  />
-
-  <!-- Section 4: What membership enables -->
-  <TextBlock
-    heading="*What* academic membership enables"
-    body="Membership provides your researchers with the same access and governance rights as all other member organisations."
-    compact
-  />
-
-  <FeatureGrid
-    columns={2}
-    features={[
-      {
-        icon: "/assets/dive-icon-1.svg",
-        title: "Participation in all Working Groups and Committees",
-        description: "Software Standards, Hardware Standards, Policy, Green AI, and Developer Relations — full participation rights from day one.",
-      },
-      {
-        icon: "/assets/dive-icon-2.svg",
-        title: "Assembly participation",
-        description: "The intensive, AI-facilitated consensus workshops where new specifications are designed. The SCI for Web specification went from a blank page to a consensus design document in ten weeks with 14 experts from 15 organisations.",
-      },
-      {
-        icon: "/assets/dive-icon-3.svg",
-        title: "Propose new specifications",
-        description: "The right to propose new specifications through the formal Assembly process — on equal footing with any other member organisation.",
-      },
-      {
-        icon: "/assets/dive-icon-4.svg",
-        title: "Chair working groups and projects",
-        description: "The right to chair working groups, sub-working groups, and projects — and to lead initiatives that shape the direction of published specifications.",
-      },
-      {
-        icon: "/assets/shape-icon-1.svg",
-        title: "Co-authorship credit",
-        description: "Co-authorship credit on published and ISO-certified specifications — including any specifications your researchers help develop.",
-      },
-      {
-        icon: "/assets/shape-icon-2.svg",
-        title: "Formal consensus rights",
-        description: "The ability to endorse, consent to, or formally object to any proposal. A single objection from any member triggers a structured resolution process. This mechanism has materially shaped the direction of published GSF specifications.",
-      },
-      {
-        icon: "/assets/shape-icon-3.svg",
-        title: "Curriculum licensing",
-        description: "Licensing for the Green Software Practitioner course and the forthcoming Green AI Practitioner course — available for integration into your institution's curriculum.",
-      },
-      {
-        icon: "/assets/shape-icon-4.svg",
-        title: "No fees",
-        description: "Both GSF and Linux Foundation membership are provided at no cost to academic institutions. There is no minimum engagement requirement.",
-      },
-    ]}
-  />
-
-  <!-- Section 5: Discipline mapping table -->
-  <section class="bg-accent-lightest-2 py-16 md:py-20">
-    <div class="container">
-      <div class="mx-auto max-w-5xl">
-        <div class="text-center mb-10">
-          <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">
-            Where academic expertise <span class="font-bold text-primary">aligns with the Foundation's work</span>
-          </h2>
-          <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
-            The table below maps research disciplines to active GSF projects — to help identify where your institution's existing research may be most relevant.
-          </p>
-        </div>
-
-        <!-- Desktop table -->
-        <div class="hidden md:block overflow-hidden rounded-xl border bg-white shadow-sm">
-          <table class="w-full text-left">
-            <thead>
-              <tr class="border-b bg-primary-darker text-white">
-                <th class="px-6 py-4 text-sm font-bold w-1/3">Discipline</th>
-                <th class="px-6 py-4 text-sm font-bold">Relevant GSF work</th>
-              </tr>
-            </thead>
-            <tbody class="text-sm text-primary-dark">
-              {[
-                {
-                  discipline: "Computer Science & Software Engineering",
-                  work: "SCI, SCI for AI, SCI for Web, SEE, Carmen, Carbon Aware SDK, Impact Framework, Green Software Patterns",
-                },
-                {
-                  discipline: "AI & Machine Learning",
-                  work: "SCI for AI, Green AI Committee, Green AI Practitioner Course, AI-accelerated consensus methodology",
-                },
-                {
-                  discipline: "Environmental Science & Sustainability",
-                  work: "SWE, lifecycle carbon accounting, SCI validation, State of Green Software Report",
-                },
-                {
-                  discipline: "Electrical & Hardware Engineering",
-                  work: "WDPC, Open19, embodied carbon in semiconductors, data centre efficiency, SCI for Circularity",
-                },
-                {
-                  discipline: "Materials Science, Industrial Ecology & Lifecycle Assessment",
-                  work: "SCI for Circularity (SCIC), lifecycle extension, material recovery, embodied carbon methodology",
-                },
-                {
-                  discipline: "Policy, Law & Governance",
-                  work: "Policy Radar, CSRD Scope 3 analysis, EU AI Act, AI Environmental Impacts Act",
-                },
-                {
-                  discipline: "Management & Organisational Science",
-                  work: "SOFT framework validation, sustainability adoption, consensus-building methodology",
-                },
-                {
-                  discipline: "Gaming & Interactive Media",
-                  work: "SCI for Games, carbon-per-hour measurement, cross-platform energy benchmarking",
-                },
-                {
-                  discipline: "HPC & Research Computing",
-                  work: "SCI applied to high-performance computing, Carbon Aware SDK for workload scheduling",
-                },
-              ].map((row, i) => (
-                <tr class={`border-b last:border-b-0 ${i % 2 === 1 ? "bg-accent-lightest-1/50" : ""}`}>
-                  <td class="px-6 py-4 font-semibold align-top">{row.discipline}</td>
-                  <td class="px-6 py-4 text-gray-darker">{row.work}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <!-- Mobile cards -->
-        <div class="space-y-3 md:hidden">
-          {[
-            { discipline: "Computer Science & Software Engineering", work: "SCI, SCI for AI, SCI for Web, SEE, Carmen, Carbon Aware SDK, Impact Framework, Green Software Patterns" },
-            { discipline: "AI & Machine Learning", work: "SCI for AI, Green AI Committee, Green AI Practitioner Course, AI-accelerated consensus methodology" },
-            { discipline: "Environmental Science & Sustainability", work: "SWE, lifecycle carbon accounting, SCI validation, State of Green Software Report" },
-            { discipline: "Electrical & Hardware Engineering", work: "WDPC, Open19, embodied carbon in semiconductors, data centre efficiency, SCI for Circularity" },
-            { discipline: "Materials Science, Industrial Ecology & Lifecycle Assessment", work: "SCI for Circularity (SCIC), lifecycle extension, material recovery, embodied carbon methodology" },
-            { discipline: "Policy, Law & Governance", work: "Policy Radar, CSRD Scope 3 analysis, EU AI Act, AI Environmental Impacts Act" },
-            { discipline: "Management & Organisational Science", work: "SOFT framework validation, sustainability adoption, consensus-building methodology" },
-            { discipline: "Gaming & Interactive Media", work: "SCI for Games, carbon-per-hour measurement, cross-platform energy benchmarking" },
-            { discipline: "HPC & Research Computing", work: "SCI applied to high-performance computing, Carbon Aware SDK for workload scheduling" },
-          ].map((row) => (
-            <div class="rounded-lg border bg-white px-5 py-4 shadow-sm">
-              <p class="font-semibold text-primary-dark text-sm">{row.discipline}</p>
-              <p class="mt-1 text-sm text-gray-darker">{row.work}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Section 6: Universities currently participating -->
+  <!-- Section 2: The Convening Model -->
   <section class="bg-white py-16 md:py-20">
     <div class="container">
-      <div class="mx-auto max-w-4xl">
-        <div class="text-center mb-10">
-          <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">
-            <span class="font-bold text-primary">17 universities</span> currently participating
-          </h2>
-          <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
-            Active GSF members contributing to standards development alongside global technology and financial services organisations.
-          </p>
-        </div>
-
-        <!-- Desktop table -->
-        <div class="hidden md:block overflow-hidden rounded-xl border shadow-sm">
-          <table class="w-full text-left">
-            <thead>
-              <tr class="border-b bg-primary-darker text-white">
-                <th class="px-6 py-4 text-sm font-bold">Institution</th>
-                <th class="px-6 py-4 text-sm font-bold">Location</th>
-              </tr>
-            </thead>
-            <tbody class="text-sm text-primary-dark">
-              {[
-                { name: "UCL", location: "London, UK" },
-                { name: "University of Edinburgh", location: "Edinburgh, UK" },
-                { name: "University of Bristol", location: "Bristol, UK" },
-                { name: "University of Amsterdam", location: "Amsterdam, Netherlands" },
-                { name: "Chalmers University of Technology", location: "Gothenburg, Sweden" },
-                { name: "Concordia University", location: "Montreal, Canada" },
-                { name: "Universidad Politécnica de Madrid", location: "Madrid, Spain" },
-                { name: "Università degli Studi dell'Aquila", location: "L'Aquila, Italy" },
-                { name: "University of Limerick", location: "Limerick, Ireland" },
-                { name: "Linnaeus University", location: "Växjö, Sweden" },
-                { name: "Manchester Metropolitan University", location: "Manchester, UK" },
-                { name: "University of Huddersfield", location: "Huddersfield, UK" },
-                { name: "University of Salento", location: "Lecce, Italy" },
-                { name: "Texas State University", location: "San Marcos, USA" },
-                { name: "Mondragon University", location: "Mondragón, Spain" },
-                { name: "IIIT Hyderabad", location: "Hyderabad, India" },
-                { name: "IIM Mumbai", location: "Mumbai, India" },
-              ].map((uni, i) => (
-                <tr class={`border-b last:border-b-0 ${i % 2 === 1 ? "bg-accent-lightest-1/50" : ""}`}>
-                  <td class="px-6 py-4 font-semibold">{uni.name}</td>
-                  <td class="px-6 py-4 text-gray-darker">{uni.location}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          <p class="px-6 py-3 text-xs text-gray-darker bg-accent-lightest-1/30 border-t">
-            Verified against the GSF Member Directory, March 2026.
-          </p>
-        </div>
-
-        <!-- Mobile cards -->
-        <div class="space-y-2 md:hidden">
-          {[
-            { name: "UCL", location: "London, UK" },
-            { name: "University of Edinburgh", location: "Edinburgh, UK" },
-            { name: "University of Bristol", location: "Bristol, UK" },
-            { name: "University of Amsterdam", location: "Amsterdam, Netherlands" },
-            { name: "Chalmers University of Technology", location: "Gothenburg, Sweden" },
-            { name: "Concordia University", location: "Montreal, Canada" },
-            { name: "Universidad Politécnica de Madrid", location: "Madrid, Spain" },
-            { name: "Università degli Studi dell'Aquila", location: "L'Aquila, Italy" },
-            { name: "University of Limerick", location: "Limerick, Ireland" },
-            { name: "Linnaeus University", location: "Växjö, Sweden" },
-            { name: "Manchester Metropolitan University", location: "Manchester, UK" },
-            { name: "University of Huddersfield", location: "Huddersfield, UK" },
-            { name: "University of Salento", location: "Lecce, Italy" },
-            { name: "Texas State University", location: "San Marcos, USA" },
-            { name: "Mondragon University", location: "Mondragón, Spain" },
-            { name: "IIIT Hyderabad", location: "Hyderabad, India" },
-            { name: "IIM Mumbai", location: "Mumbai, India" },
-          ].map((uni) => (
-            <div class="flex items-center justify-between rounded-lg border bg-white px-5 py-3 shadow-sm">
-              <span class="font-semibold text-primary-dark text-sm">{uni.name}</span>
-              <span class="text-sm text-gray-darker">{uni.location}</span>
-            </div>
-          ))}
-          <p class="pt-2 text-xs text-gray-darker text-center">Verified against the GSF Member Directory, March 2026.</p>
-        </div>
+      <div class="mx-auto max-w-3xl">
+        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">The Convening Model</h2>
+        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
+          GSF operates at the intersection of two populations that rarely meet with the right structure in place: industry organisations with specific, unsolved green software problems — and research institutions with the methodology and rigour to address them.
+        </p>
+        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
+          The Foundation's role is to hold the network, run the matching process, and provide the governance infrastructure through which collaboration becomes output — a white paper, a co-authored technical report, or a ratified specification that changes how the industry reduces software carbon.
+        </p>
+        <p class="mt-8 font-semibold text-primary-dark">
+          Browse the current areas of research interest submitted by the GSF members or…
+        </p>
+        <ol class="mt-3 list-decimal list-outside space-y-3 pl-5">
+          <li class="text-base leading-relaxed text-primary-dark">
+            Institutions submit an idea, proposal, or white paper using the form on this page.
+          </li>
+          <li class="text-base leading-relaxed text-primary-dark">
+            The GSF Policy Working Group reviews all submissions and determines the appropriate form of engagement — which may include connection to a specific industry member, integration into an active Assembly or working group, or co-authorship on a GSF publication.
+          </li>
+          <li class="text-base leading-relaxed text-primary-dark">
+            Where a strong match exists between a research submission and an active industry member challenge, GSF facilitates the introduction — subject to review and approval by the Policy Working Group.
+          </li>
+          <li class="text-base leading-relaxed text-primary-dark">
+            Substantive collaborations may progress toward formal academic membership — available at no cost for qualifying institutions.
+          </li>
+        </ol>
+        <p class="mt-6 text-sm text-gray-darker">
+          There is no guaranteed outcome from submission. All substantive proposals receive a considered review, and the process has genuine governance integrity — decisions are made collectively, not by a single point of contact.
+        </p>
       </div>
     </div>
   </section>
 
-  <!-- Section 7: Relevance to institutional sustainability objectives -->
-  <TextWithImage
-    heading="Relevance to your institution's"
-    headingAccent="sustainability objectives"
-    body="Universities operate computationally intensive infrastructure — HPC clusters, research data centres, AI training facilities, campus IT systems — and face the same measurement and reporting requirements as commercial organisations. The SCI specification provides a standardised, ISO-certified method to measure the carbon intensity of institutional computation. The SEE and SWE specifications extend this to energy and water. The WDPC and Open19 hardware standards address the physical infrastructure layer. The forthcoming SCI for Circularity specification will be directly applicable to university hardware procurement, refresh cycles, and e-waste management. The SOFT framework supports systematic implementation across departments and faculties. Institutions applying GSF standards to their own infrastructure also generate implementation case studies that strengthen the specifications and demonstrate their applicability beyond commercial settings."
-    imageSrc="/assets/dive-illustration.svg"
-    imageAlt="Institutional sustainability illustration"
-  />
-
-  <!-- Section 8: Complementary academic programmes -->
-  <ResourceCards
-    heading="Complementary *academic programmes*"
-    body="GSF's standards portfolio intersects with several established academic initiatives."
-    columns={2}
-    cards={[
-      {
-        icon: "/assets/shape-icon-1.svg",
-        title: "Erasmus Mundus SE4GD",
-        description: "The joint Master's programme in Software Engineering for Green Deal, across LUT University (Finland), Università degli Studi dell'Aquila (Italy), and Vrije Universiteit Amsterdam (Netherlands). Two of the three consortium universities are GSF members. The programme's curriculum aligns with GSF's standards portfolio.",
-        ctaText: "Learn about SE4GD →",
-        ctaHref: "https://se4gd.lutfoundation.fi",
-      },
-      {
-        icon: "/assets/shape-icon-2.svg",
-        title: "GREENER Principles",
-        description: "The framework for environmentally sustainable computational science (Lannelongue et al., Nature Computational Science, 2023). GSF standards provide the measurement methodology these principles require.",
-        ctaText: "Read the paper →",
-        ctaHref: "https://doi.org/10.1038/s43588-023-00461-y",
-      },
-      {
-        icon: "/assets/shape-icon-3.svg",
-        title: "ARCHER2 Sustainable HPC Training",
-        description: "The UK national supercomputing service references GSF principles and the SCI methodology in its sustainable computing curriculum.",
-        ctaText: "Visit ARCHER2 →",
-        ctaHref: "https://www.archer2.ac.uk",
-      },
-      {
-        icon: "/assets/shape-icon-4.svg",
-        title: "Texas State University SCI Validation",
-        description: "Published research from a GSF academic member confirming SCI as an effective metric for evaluating the carbon impact of foundation models — independent validation from within the academic community.",
-        ctaText: "View the research →",
-        ctaHref: "/policy/research/",
-      },
-    ]}
-  />
-
-  <!-- Section 9: How to enquire -->
-  <FeatureGrid
-    heading="How to *enquire*"
-    body="If your institution has research aligned with the Foundation's work and you would like to explore membership:"
-    variant="bordered"
-    columns={2}
-    features={[
-      {
-        icon: "/assets/dive-icon-1.svg",
-        title: "1. Get in touch",
-        description: "Contact Jamie Cowan, Head of Sales & Partnerships — jamie.cowan@greensoftware.foundation. Academic membership is free and the process is straightforward.",
-      },
-      {
-        icon: "/assets/dive-icon-2.svg",
-        title: "2. Brief alignment conversation",
-        description: "A short conversation to identify which working groups, committees, or projects represent the strongest fit for your researchers.",
-      },
-      {
-        icon: "/assets/dive-icon-3.svg",
-        title: "3. Formal enrolment",
-        description: "Completed through the Linux Foundation portal. The process carries no fees for academic institutions — neither GSF nor Linux Foundation membership.",
-      },
-      {
-        icon: "/assets/dive-icon-4.svg",
-        title: "4. Onboarding",
-        description: "Introduction to relevant project chairs, access to repositories and communication channels, and connection with existing academic members working in adjacent areas.",
-      },
-    ]}
-  />
-
-  <!-- Section 10: FAQ -->
+  <!-- Section 3: What Our Members Are Working On -->
   <section class="bg-accent-lightest-2 py-16 md:py-20">
     <div class="container">
+      <h2 class="text-center text-2xl font-semibold md:text-3xl lg:text-4xl">
+        What Our Members Are Working On
+      </h2>
+      <p class="mx-auto mt-4 max-w-2xl text-center text-base text-primary-dark md:text-lg">
+        GSF member organisations — spanning global banks, technology companies, infrastructure providers, and automotive manufacturers — regularly surface specific green software challenges that academic research is positioned to address.
+      </p>
+      <div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {workingOnCards.map((card) => (
+          <div class="rounded-lg border bg-white p-5 shadow-sm">
+            <img src={card.icon} alt="" class="mb-4 h-10 w-10" loading="lazy" decoding="async" />
+            <h3 class="text-lg font-bold text-primary">{card.title}</h3>
+            <p class="mt-2 text-sm text-gray-darker">{card.description}</p>
+          </div>
+        ))}
+      </div>
+      <p class="mx-auto mt-8 max-w-2xl text-center text-sm text-gray-darker">
+        If your institution is active in any of these areas, use the submission form below. Our members' problem statements evolve as the field develops. This list is not exhaustive, and we welcome suggestions.
+      </p>
+    </div>
+  </section>
+
+  <!-- Section 4: Forms of Engagement -->
+  <section class="bg-white py-16 md:py-20">
+    <div class="container">
       <div class="mx-auto max-w-3xl">
-        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl text-center mb-10">
-          Frequently asked <span class="font-bold text-primary">questions</span>
-        </h2>
-        <div class="space-y-3">
-          {[
-            {
-              q: "Is membership genuinely free for academic institutions?",
-              a: "Yes. Both GSF and Linux Foundation membership are provided at no cost to academic institutions, non-profits, and government organisations.",
-            },
-            {
-              q: "Can postgraduate students and early-career researchers participate?",
-              a: "Yes. Any enrolled student or employee at a member institution may register and participate in working groups and projects.",
-            },
-            {
-              q: "Can we integrate GSF materials into our teaching?",
-              a: "Yes. The Green Software Practitioner course and related materials are available for curriculum integration. Licensing is discussed during onboarding.",
-            },
-            {
-              q: "Can we propose new specifications?",
-              a: "Yes. Academic members have the same rights as any other member to propose and lead new initiatives through the Assembly process.",
-            },
-            {
-              q: "How does GSF relate to the SE4GD programme?",
-              a: "Two of the three SE4GD consortium universities are GSF members. The programme's curriculum and GSF's standards portfolio are closely aligned. We welcome further collaboration with SE4GD-affiliated institutions.",
-            },
-          ].map((item) => (
-            <details class="group rounded-xl border bg-white shadow-sm open:shadow-md transition-shadow">
-              <summary class="flex cursor-pointer items-center justify-between gap-4 px-6 py-5 font-semibold text-primary-dark list-none">
-                <span>{item.q}</span>
-                <span class="shrink-0 text-primary transition-transform group-open:rotate-45 text-xl leading-none">+</span>
-              </summary>
-              <div class="px-6 pb-5 text-sm leading-relaxed text-gray-darker border-t pt-4">
-                {item.a}
-              </div>
-            </details>
+        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Forms of Engagement</h2>
+        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
+          Engagement with the Green Software Foundation is not a single pathway. The following forms have emerged from real collaborations.
+        </p>
+        <ul class="mt-6 space-y-4">
+          {engagementForms.map((item) => (
+            <li class="text-base leading-relaxed text-primary-dark">
+              <span class="font-bold">{item.title}</span>{item.body}
+            </li>
           ))}
-        </div>
+        </ul>
       </div>
     </div>
   </section>
 
-  <!-- Section 11: Final CTA -->
-  <CTABanner
-    heading="Academic membership is *provided at no cost*"
-    body="Both GSF and Linux Foundation membership are free for academic institutions. If your institution has research aligned with our work, membership may warrant a conversation."
-    ctaText="Enquire about academic membership"
-    ctaHref="/membership/enquire/"
-  />
+  <!-- Section 5: Standards — Active Research Areas -->
+  <section class="bg-accent-lightest-2 py-16 md:py-20">
+    <div class="container">
+      <h2 class="text-center text-2xl font-semibold md:text-3xl lg:text-4xl">
+        Standards — Active Research Areas
+      </h2>
+      <p class="mx-auto mt-4 max-w-2xl text-center text-base text-primary-dark md:text-lg">
+        GSF produces and maintains ISO-certified standards. The following specifications have active, open research needs.
+      </p>
+      <div class="mt-12 grid gap-6 sm:grid-cols-2">
+        {standardsItems.map((item) => (
+          <div class="rounded-lg border bg-white p-5 shadow-sm">
+            <h3 class="text-lg font-bold text-primary">{item.title}</h3>
+            <p class="mt-2 text-sm text-gray-darker">{item.description}</p>
+            {item.link && (
+              <a
+                href={item.link}
+                class="mt-3 inline-flex items-center text-sm font-bold text-primary hover:underline"
+              >
+                {item.linkText}
+              </a>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 6: Academic Membership -->
+  <section class="bg-white py-16 md:py-20">
+    <div class="container">
+      <div class="mx-auto max-w-3xl">
+        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Academic Membership</h2>
+        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
+          Academic membership in the Green Software Foundation is the formal relationship that follows substantive engagement when research and mission are genuinely aligned.
+        </p>
+        <ul class="mt-6 space-y-4">
+          {membershipBenefits.map((item) => (
+            <li class="text-base leading-relaxed text-primary-dark">
+              <span class="font-bold">{item.title}</span> — {item.body}
+            </li>
+          ))}
+        </ul>
+        <p class="mt-6 text-sm text-gray-darker">
+          Academic membership is available at no cost for qualifying institutions. Membership decisions are made at the Policy Working Group level.
+        </p>
+        <p class="mt-6 text-base text-primary-dark">
+          <span class="font-semibold">Current academic members:</span>{" "}Chalmers University of Technology · Concordia University · University College London · University of Amsterdam · University of Bristol · University of Edinburgh · Manchester Metropolitan University · Texas State University
+        </p>
+        <p class="mt-4 font-semibold text-primary-dark">
+          Academic engagement within the GSF is established, not experimental.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 7: Submission Form -->
+  <section id="submission-form" class="bg-accent-lightest-2 py-16 md:py-20">
+    <div class="container">
+      <div class="mx-auto max-w-2xl">
+        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Submit a Proposal</h2>
+        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
+          Submit your proposal, idea, or white paper using the form below. All submissions are reviewed by the GSF Policy Working Group, which determines next steps for engagement — including whether your research connects with an active challenge from a GSF member organisation.
+        </p>
+
+        <div id="submission-form-wrap" class="mt-8">
+          <form id="academic-submission-form" class="space-y-5" novalidate>
+            <div>
+              <label for="full-name" class="mb-1 block text-sm font-semibold text-primary-dark">
+                Full name <span class="text-primary">*</span>
+              </label>
+              <input
+                type="text"
+                id="full-name"
+                name="full-name"
+                required
+                class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="job-title" class="mb-1 block text-sm font-semibold text-primary-dark">
+                Job title <span class="text-primary">*</span>
+              </label>
+              <input
+                type="text"
+                id="job-title"
+                name="job-title"
+                required
+                class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="institution" class="mb-1 block text-sm font-semibold text-primary-dark">
+                Institution name <span class="text-primary">*</span>
+              </label>
+              <input
+                type="text"
+                id="institution"
+                name="institution"
+                required
+                class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="email" class="mb-1 block text-sm font-semibold text-primary-dark">
+                Email address <span class="text-primary">*</span>
+              </label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                required
+                class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="research-area" class="mb-1 block text-sm font-semibold text-primary-dark">
+                Brief description of your research area <span class="text-primary">*</span>
+              </label>
+              <textarea
+                id="research-area"
+                name="research-area"
+                required
+                rows={5}
+                class="w-full resize-y rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              ></textarea>
+              <p class="mt-1 text-xs text-gray-darker">Max 300 words</p>
+            </div>
+            <div>
+              <label for="member-collab" class="mb-1 block text-sm font-semibold text-primary-dark">
+                Are you aware of any specific GSF member organisations you would like to explore
+                collaboration with?
+              </label>
+              <textarea
+                id="member-collab"
+                name="member-collab"
+                rows={3}
+                class="w-full resize-y rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              ></textarea>
+              <p class="mt-1 text-xs text-gray-darker">Optional · Max 100 words</p>
+            </div>
+            <div class="pt-2">
+              <button
+                type="submit"
+                class="rounded-lg bg-primary px-6 py-3 text-sm font-bold text-white transition-colors hover:bg-primary-dark"
+              >
+                Submit for Review
+              </button>
+            </div>
+            <p class="text-xs text-gray-darker">
+              By submitting this form you agree to GSF's{" "}
+              <a href="/privacy/" class="underline hover:text-primary-dark">privacy policy</a>.
+              Submissions are reviewed by the GSF Policy Working Group. We aim to acknowledge all
+              substantive submissions, though we do not publish a fixed response time.
+            </p>
+          </form>
+
+          <div
+            id="submission-confirmation"
+            class="hidden rounded-xl border border-primary/30 bg-white px-6 py-10 text-center shadow-sm"
+          >
+            <p class="text-lg font-semibold text-primary-dark">
+              Thank you — your submission has been received.
+            </p>
+            <p class="mt-3 text-sm text-gray-darker">
+              The GSF Policy Working Group will review your proposal. We aim to acknowledge all
+              substantive submissions.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 
   <Footer />
 </Layout>
+
+<script>
+  const form = document.getElementById("academic-submission-form") as HTMLFormElement | null;
+  const confirmation = document.getElementById("submission-confirmation");
+
+  if (form && confirmation) {
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      form.classList.add("hidden");
+      confirmation.classList.remove("hidden");
+    });
+  }
+</script>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -318,12 +318,8 @@ const researchProgramme = [
 const greenAICommitteeMembers = [
   { name: "Sanjay Podder", org: "Accenture", role: "Co-Chair" },
   { name: "Thomas Lewis", org: "Microsoft", role: "Co-Chair" },
-  { name: "Arun Ravindran", org: "BCG", role: "Member" },
-  { name: "Chris Xie", org: "Futurewei", role: "Member" },
   { name: "Federica Sarro", org: "UCL", role: "Member" },
   { name: "Gadhu Sundaram", org: "NTT Data", role: "Member" },
-  { name: "Juan José Lopez Murphy", org: "Globant", role: "Member" },
-  { name: "Nadim Kapadia", org: "HSBC", role: "Member" },
   { name: "Nisha Menon", org: "Siemens", role: "Member" },
   { name: "Savannah Goodman", org: "Google", role: "Member" },
   { name: "Vincent Caldeira", org: "IBM / Red Hat", role: "Member" },
@@ -722,39 +718,39 @@ const membershipBenefits = [
           <!-- Co-chairs featured row -->
           <div class="mb-6 grid gap-4 sm:grid-cols-2">
             {committeeWithLogos.filter(m => m.role === "Co-Chair").map((member) => (
-              <div class="flex items-center gap-4 rounded-xl border border-accent/40 bg-white/10 p-4 backdrop-blur-sm">
-                <div class="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white">
+              <div class="flex items-center gap-4 rounded-xl border border-white/20 bg-white p-5">
+                <div class="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-accent-lightest-2 p-2">
                   {member.logo ? (
-                    <img src={member.logo} alt={member.org} class="h-10 w-10 object-contain" loading="lazy" decoding="async" />
+                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
                   ) : (
-                    <span class="text-lg font-extrabold text-primary">{member.initials}</span>
+                    <span class="text-xl font-extrabold text-primary">{member.initials}</span>
                   )}
                 </div>
                 <div class="min-w-0">
                   <div class="flex flex-wrap items-center gap-2">
-                    <p class="text-sm font-extrabold text-white">{member.name}</p>
+                    <p class="text-sm font-extrabold text-primary-dark">{member.name}</p>
                     <span class="rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
                   </div>
-                  <p class="mt-0.5 text-xs text-white/60">{member.org}</p>
+                  <p class="mt-0.5 text-xs text-gray-darker">{member.org}</p>
                 </div>
               </div>
             ))}
           </div>
 
           <!-- Regular members grid -->
-          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {committeeWithLogos.filter(m => m.role !== "Co-Chair").map((member) => (
-              <div class="flex items-center gap-3 rounded-xl bg-white/10 p-3.5">
-                <div class="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white">
+              <div class="flex items-center gap-4 rounded-xl border border-white/20 bg-white p-4">
+                <div class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-accent-lightest-2 p-1.5">
                   {member.logo ? (
-                    <img src={member.logo} alt={member.org} class="h-7 w-7 object-contain" loading="lazy" decoding="async" />
+                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
                   ) : (
-                    <span class="text-xs font-extrabold text-primary">{member.initials}</span>
+                    <span class="text-sm font-extrabold text-primary">{member.initials}</span>
                   )}
                 </div>
                 <div class="min-w-0">
-                  <p class="truncate text-sm font-semibold leading-tight text-white">{member.name}</p>
-                  <p class="truncate text-xs text-white/50">{member.org}</p>
+                  <p class="truncate text-sm font-semibold leading-tight text-primary-dark">{member.name}</p>
+                  <p class="truncate text-xs text-gray-darker">{member.org}</p>
                 </div>
               </div>
             ))}

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -710,48 +710,42 @@ const membershipBenefits = [
 
         <!-- Committee Members -->
         <div class="mt-14">
-          <div class="mb-8 flex items-center gap-4">
+          <div class="mb-10 flex items-center gap-4">
             <p class="shrink-0 text-xs font-bold uppercase tracking-widest text-white/50">Committee Members</p>
             <div class="h-px flex-1 bg-white/20"></div>
           </div>
 
           <!-- Co-chairs featured row -->
-          <div class="mb-6 grid gap-4 sm:grid-cols-2">
+          <div class="mb-6 grid gap-6 sm:grid-cols-2">
             {committeeWithLogos.filter(m => m.role === "Co-Chair").map((member) => (
-              <div class="flex items-center gap-4 rounded-xl border border-white/20 bg-white p-5">
-                <div class="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-accent-lightest-2 p-2">
+              <div class="flex flex-col items-center rounded-2xl bg-white p-8 text-center shadow-md">
+                <div class="flex h-28 w-28 items-center justify-center overflow-hidden rounded-2xl bg-white p-3 shadow-sm ring-1 ring-black/5">
+                  {member.logo ? (
+                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
+                  ) : (
+                    <span class="text-3xl font-extrabold text-primary">{member.initials}</span>
+                  )}
+                </div>
+                <span class="mt-5 inline-block rounded-full bg-accent px-3 py-1 text-xs font-bold text-primary-dark">Co-Chair</span>
+                <p class="mt-2 text-base font-extrabold text-primary-dark">{member.name}</p>
+                <p class="mt-1 text-sm text-gray-darker">{member.org}</p>
+              </div>
+            ))}
+          </div>
+
+          <!-- Regular members grid -->
+          <div class="grid gap-4 sm:grid-cols-3">
+            {committeeWithLogos.filter(m => m.role !== "Co-Chair").map((member) => (
+              <div class="flex flex-col items-center rounded-xl bg-white p-6 text-center shadow-sm">
+                <div class="flex h-20 w-20 items-center justify-center overflow-hidden rounded-xl bg-white p-2 shadow-sm ring-1 ring-black/5">
                   {member.logo ? (
                     <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
                   ) : (
                     <span class="text-xl font-extrabold text-primary">{member.initials}</span>
                   )}
                 </div>
-                <div class="min-w-0">
-                  <div class="flex flex-wrap items-center gap-2">
-                    <p class="text-sm font-extrabold text-primary-dark">{member.name}</p>
-                    <span class="rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
-                  </div>
-                  <p class="mt-0.5 text-xs text-gray-darker">{member.org}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          <!-- Regular members grid -->
-          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {committeeWithLogos.filter(m => m.role !== "Co-Chair").map((member) => (
-              <div class="flex items-center gap-4 rounded-xl border border-white/20 bg-white p-4">
-                <div class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-accent-lightest-2 p-1.5">
-                  {member.logo ? (
-                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
-                  ) : (
-                    <span class="text-sm font-extrabold text-primary">{member.initials}</span>
-                  )}
-                </div>
-                <div class="min-w-0">
-                  <p class="truncate text-sm font-semibold leading-tight text-primary-dark">{member.name}</p>
-                  <p class="truncate text-xs text-gray-darker">{member.org}</p>
-                </div>
+                <p class="mt-4 text-sm font-bold text-primary-dark">{member.name}</p>
+                <p class="mt-0.5 text-xs text-gray-darker">{member.org}</p>
               </div>
             ))}
           </div>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -5,6 +5,7 @@ import { navItems } from "@/lib/nav-items";
 import Navbar from "@/components/navbar.astro";
 import Hero from "@/components/hero.astro";
 import Footer from "@/components/footer.astro";
+import Testimonial from "@/components/testimonial.astro";
 
 const heroBody = [
   "The Green Software Foundation is where a computer science department's measurement methodology research connects directly to the ESG reporting reality of a Fortune 500 company implementing it next quarter. No other organisation holds both sides of that relationship simultaneously.",
@@ -175,42 +176,84 @@ const membershipBenefits = [
   />
 
   <!-- Section 2: The Convening Model -->
-  <section class="bg-white py-16 md:py-20">
+  <section class="bg-white py-16 md:py-24">
     <div class="container">
-      <div class="mx-auto max-w-3xl">
-        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">The Convening Model</h2>
-        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
-          GSF operates at the intersection of two populations that rarely meet with the right structure in place: industry organisations with specific, unsolved green software problems — and research institutions with the methodology and rigour to address them.
-        </p>
-        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
-          The Foundation's role is to hold the network, run the matching process, and provide the governance infrastructure through which collaboration becomes output — a white paper, a co-authored technical report, or a ratified specification that changes how the industry reduces software carbon.
-        </p>
-        <p class="mt-8 font-semibold text-primary-dark">
-          Browse the current areas of research interest submitted by the GSF members or…
-        </p>
-        <ol class="mt-3 list-decimal list-outside space-y-3 pl-5">
-          <li class="text-base leading-relaxed text-primary-dark">
-            Institutions submit an idea, proposal, or white paper using the form on this page.
-          </li>
-          <li class="text-base leading-relaxed text-primary-dark">
-            The GSF Policy Working Group reviews all submissions and determines the appropriate form of engagement — which may include connection to a specific industry member, integration into an active Assembly or working group, or co-authorship on a GSF publication.
-          </li>
-          <li class="text-base leading-relaxed text-primary-dark">
-            Where a strong match exists between a research submission and an active industry member challenge, GSF facilitates the introduction — subject to review and approval by the Policy Working Group.
-          </li>
-          <li class="text-base leading-relaxed text-primary-dark">
-            Substantive collaborations may progress toward formal academic membership — available at no cost for qualifying institutions.
-          </li>
-        </ol>
-        <p class="mt-6 text-sm text-gray-darker">
-          There is no guaranteed outcome from submission. All substantive proposals receive a considered review, and the process has genuine governance integrity — decisions are made collectively, not by a single point of contact.
-        </p>
+      <p class="mb-3 text-center text-xs font-bold uppercase tracking-widest text-primary">How It Works</p>
+      <h2 class="text-center text-2xl font-extrabold md:text-3xl lg:text-4xl">The Convening <span class="text-primary">Model</span></h2>
+
+      <div class="mx-auto mt-8 grid max-w-5xl gap-6 md:grid-cols-2 md:gap-10">
+        <div class="rounded-2xl border border-accent-lighter bg-accent-lightest-2 p-6 md:p-8">
+          <p class="text-base leading-relaxed text-primary-dark">
+            GSF operates at the intersection of two populations that rarely meet with the right structure in place: industry organisations with specific, unsolved green software problems — and research institutions with the methodology and rigour to address them.
+          </p>
+        </div>
+        <div class="rounded-2xl border border-accent-lighter bg-accent-lightest-2 p-6 md:p-8">
+          <p class="text-base leading-relaxed text-primary-dark">
+            The Foundation's role is to hold the network, run the matching process, and provide the governance infrastructure through which collaboration becomes output — a white paper, a co-authored technical report, or a ratified specification that changes how the industry reduces software carbon.
+          </p>
+        </div>
+      </div>
+
+      <div class="mx-auto mt-12 max-w-2xl">
+        <p class="text-center text-sm font-semibold uppercase tracking-wide text-primary">How engagement works</p>
+        <div class="mt-6 space-y-0">
+          {[
+            "Institutions submit an idea, proposal, or white paper using the form on this page.",
+            "The GSF Policy Working Group reviews all submissions and determines the appropriate form of engagement — which may include connection to a specific industry member, integration into an active Assembly or working group, or co-authorship on a GSF publication.",
+            "Where a strong match exists between a research submission and an active industry member challenge, GSF facilitates the introduction — subject to review and approval by the Policy Working Group.",
+            "Substantive collaborations may progress toward formal academic membership — available at no cost for qualifying institutions.",
+          ].map((step, i) => (
+            <div class="relative flex gap-5">
+              <div class="flex flex-col items-center">
+                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-bold text-white">
+                  {i + 1}
+                </div>
+                {i < 3 && <div class="w-0.5 grow bg-primary-lighter my-1" />}
+              </div>
+              <div class={`${i < 3 ? "pb-6" : "pb-0"} pt-1.5`}>
+                <p class="text-base leading-relaxed text-primary-dark">{step}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div class="mt-8 rounded-xl border-l-4 border-primary bg-accent-lightest-2 px-5 py-4">
+          <p class="text-sm text-gray-darker">
+            There is no guaranteed outcome from submission. All substantive proposals receive a considered review, and the process has genuine governance integrity — decisions are made collectively, not by a single point of contact.
+          </p>
+        </div>
       </div>
     </div>
   </section>
 
-  <!-- Section 3: What Our Members Are Working On -->
+  <!-- Section 3: Forms of Engagement (moved above What Our Members Are Working On) -->
   <section class="bg-accent-lightest-2 py-16 md:py-20">
+    <div class="container">
+      <h2 class="text-center text-2xl font-semibold md:text-3xl lg:text-4xl">Forms of Engagement</h2>
+      <p class="mx-auto mt-4 max-w-2xl text-center text-base leading-relaxed text-primary-dark md:text-lg">
+        Engagement with GSF is not a single pathway. The following forms have emerged from real collaborations.
+      </p>
+      <div class="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {engagementForms.map((item) => (
+          <div class="flex flex-col rounded-xl border bg-white p-6">
+            <h3 class="text-lg font-extrabold text-primary-dark">{item.title}</h3>
+            <p class="mt-3 flex-1 text-base leading-relaxed text-primary-dark">{item.body}</p>
+            <div class="mt-5">
+              <a
+                href={item.buttonHref}
+                class="inline-block rounded-lg border border-primary px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary hover:text-white"
+              >
+                {item.buttonText}
+              </a>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 4: What Our Members Are Working On -->
+  <section class="bg-white py-16 md:py-20">
     <div class="container">
       <h2 class="text-center text-2xl font-semibold md:text-3xl lg:text-4xl">
         What Our Members Are Working On
@@ -235,7 +278,7 @@ const membershipBenefits = [
               </div>
             </div>
           ) : (
-            <div class="flex flex-col rounded-lg border bg-white p-5 shadow-sm">
+            <div class="flex flex-col rounded-lg border bg-accent-lightest-2 p-5 shadow-sm">
               <img src={card.icon} alt="" class="mb-4 h-10 w-10" loading="lazy" decoding="async" />
               <h3 class="text-lg font-bold text-primary">{card.title}</h3>
               <p class="mt-2 flex-1 text-sm text-gray-darker">{card.description}</p>
@@ -253,37 +296,15 @@ const membershipBenefits = [
           )
         ))}
       </div>
-      <p class="mx-auto mt-8 max-w-2xl text-center text-sm text-gray-darker">
-        If your institution is active in any of these areas, use the submission form below. Our members' problem statements evolve as the field develops. This list is not exhaustive, and we welcome suggestions.
-      </p>
     </div>
   </section>
 
-  <!-- Section 4: Forms of Engagement -->
-  <section class="bg-white py-16 md:py-20">
-    <div class="container">
-      <h2 class="text-center text-2xl font-semibold md:text-3xl lg:text-4xl">Forms of Engagement</h2>
-      <p class="mx-auto mt-4 max-w-2xl text-center text-base leading-relaxed text-primary-dark md:text-lg">
-        Engagement with GSF is not a single pathway. The following forms have emerged from real collaborations.
-      </p>
-      <div class="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-        {engagementForms.map((item) => (
-          <div class="flex flex-col rounded-xl border bg-accent-lightest-2 p-6">
-            <h3 class="text-lg font-extrabold text-primary-dark">{item.title}</h3>
-            <p class="mt-3 flex-1 text-base leading-relaxed text-primary-dark">{item.body}</p>
-            <div class="mt-5">
-              <a
-                href={item.buttonHref}
-                class="inline-block rounded-lg border border-primary px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary hover:text-white"
-              >
-                {item.buttonText}
-              </a>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  </section>
+  <Testimonial
+    quote="If your institution is active in any of these areas, use the submission form below. Our members' problem statements evolve as the field develops. This list is not exhaustive, and we welcome suggestions."
+    author="Gadhu Sundaram"
+    title="Chairperson"
+    company="Green Software Foundation"
+  />
 
   <!-- Section 5: Standards — Active Research Areas -->
   <section class="bg-accent-lightest-2 py-16 md:py-20">

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -16,32 +16,49 @@ const workingOnCards = [
   {
     title: "AI Workload Carbon Quantification",
     description:
-      "Measuring the full lifecycle footprint of AI systems across training, inference, and end-of-life. Direct input into the SCI for AI standard, ratified December 2025.",
+      "The SCI for AI standard (ratified December 2025) is the first consensus-based methodology for measuring the carbon footprint of AI systems across six lifecycle stages — training, fine-tuning, inference, storage, transmission, and end-of-life. GSF members need independent academic input to validate training-versus-inference carbon apportionment, embodied carbon in AI hardware, and optimisation of long-running workloads.",
     icon: "/assets/realtime-icon.svg",
+    link: "/standards/sci-ai/",
+    linkText: "About SCI for AI",
   },
   {
     title: "Carbon-Aware Scheduling Methodology",
     description:
-      "Optimising when and where software workloads run based on grid carbon intensity. A UCL carbon-aware scheduler project, presented to the GSF Steering Committee in April 2026, demonstrated 44–56% carbon savings through temporal and spatial scheduling.",
+      "Carbon-aware scheduling shifts computational workloads to times and locations where electricity grids are running on lower-carbon sources. A UCL research project presented to the GSF Steering Committee in April 2026 demonstrated 44–56% carbon savings through temporal and spatial scheduling — a result that directly informed active work on GSF standards.",
     icon: "/assets/co2-icon.svg",
   },
   {
     title: "SCI Methodology Validation",
     description:
-      "Independent academic validation of Software Carbon Intensity measurement approaches under CSRD Scope 3 reporting requirements carries regulatory and procurement weight that industry-produced documentation does not.",
+      "The Software Carbon Intensity standard (ISO/IEC 21031:2024) is the only ISO-certified metric for measuring the carbon footprint of software systems. Under CSRD Scope 3 reporting requirements, independent academic validation of SCI measurement approaches carries regulatory and procurement weight that industry-produced documentation cannot provide — giving academic researchers a direct route to policy-relevant impact.",
     icon: "/assets/standardized-icon.svg",
+    link: "/standards/sci/",
+    linkText: "About the SCI Standard",
   },
   {
     title: "Data Centre Water & Energy Baseline Standards",
     description:
-      "Establishing defensible measurement baselines for water consumption and energy use across hyperscale and edge infrastructure.",
+      "The WDPC standard addresses measurement of power, cooling, and water consumption in data centres. Establishing defensible measurement baselines for water and energy use across hyperscale and edge infrastructure is an active research need — particularly as EU and national regulations introduce mandatory environmental reporting for digital infrastructure operators.",
     icon: "/assets/shape-icon-1.svg",
+    link: "/standards/wdpc/",
+    linkText: "About the WDPC Standard",
   },
   {
     title: "SCI for Web",
     description:
-      "Extending Software Carbon Intensity methodology to web-based systems. An early-stage specification where academic input into design foundations is directly relevant.",
+      "SCI for Web is an early-stage specification extending Software Carbon Intensity methodology to web-based software systems — addressing client-side rendering, CDN energy use, and carbon measurement across distributed web architectures. Because the standard is still in development, academic input into its design foundations is actively sought.",
     icon: "/assets/shape-icon-2.svg",
+    link: "/standards/sci-web/",
+    linkText: "About SCI for Web",
+  },
+  {
+    title: "Your Research. Your Vision.",
+    description:
+      "GSF members are actively looking for research that addresses unsolved green software problems. If your institution is working in this field and you don't see your area above, tell us about it — we welcome proposals, ideas, and white papers on any aspect of software sustainability.",
+    icon: "/assets/shape-icon-2.svg",
+    link: "#submission-form",
+    linkText: "Submit Your Idea",
+    cta: true,
   },
 ];
 
@@ -203,11 +220,37 @@ const membershipBenefits = [
       </p>
       <div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {workingOnCards.map((card) => (
-          <div class="rounded-lg border bg-white p-5 shadow-sm">
-            <img src={card.icon} alt="" class="mb-4 h-10 w-10" loading="lazy" decoding="async" />
-            <h3 class="text-lg font-bold text-primary">{card.title}</h3>
-            <p class="mt-2 text-sm text-gray-darker">{card.description}</p>
-          </div>
+          card.cta ? (
+            <div class="flex flex-col rounded-lg border-2 border-dashed border-primary bg-primary/5 p-5">
+              <img src={card.icon} alt="" class="mb-4 h-10 w-10 opacity-60" loading="lazy" decoding="async" />
+              <h3 class="text-lg font-bold text-primary">{card.title}</h3>
+              <p class="mt-2 flex-1 text-sm text-primary-dark">{card.description}</p>
+              <div class="mt-4">
+                <a
+                  href={card.link}
+                  class="inline-block rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-dark"
+                >
+                  {card.linkText}
+                </a>
+              </div>
+            </div>
+          ) : (
+            <div class="flex flex-col rounded-lg border bg-white p-5 shadow-sm">
+              <img src={card.icon} alt="" class="mb-4 h-10 w-10" loading="lazy" decoding="async" />
+              <h3 class="text-lg font-bold text-primary">{card.title}</h3>
+              <p class="mt-2 flex-1 text-sm text-gray-darker">{card.description}</p>
+              {card.link && (
+                <div class="mt-4">
+                  <a
+                    href={card.link}
+                    class="inline-flex items-center text-sm font-semibold text-primary hover:underline"
+                  >
+                    {card.linkText} →
+                  </a>
+                </div>
+              )}
+            </div>
+          )
         ))}
       </div>
       <p class="mx-auto mt-8 max-w-2xl text-center text-sm text-gray-darker">

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -357,7 +357,7 @@ const membershipBenefits = [
 
   <!-- Section 1: Hero -->
   <Hero
-    badge="Green Software Foundation · Academic & Research Engagement"
+    badge="Academic & Research Engagement"
     heading="Where Research"
     headingAccent="Becomes Standard"
     body={heroBody}

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -689,32 +689,30 @@ const membershipBenefits = [
   </section>
 
   <!-- Green AI Committee full-width section -->
-  <section class="bg-primary py-16 md:py-20">
+  <section class="bg-primary py-14 md:py-16">
     <div class="container">
-      <!-- Header + CTAs -->
-      <div class="mb-10">
-        <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">GSF Committee</p>
-        <h2 class="mb-6 text-2xl font-extrabold text-white md:text-3xl lg:text-4xl">Green AI Committee</h2>
-        <div class="flex flex-wrap gap-3">
-          <a
-            href="#submission-form"
-            class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
-          >
-            GSF Academic Members can join the Green AI Committee →
-          </a>
-          <a
-            href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
-            class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
-          >
-            EU AI Act analysis →
-          </a>
-        </div>
-      </div>
-
-      <!-- Left-right layout: text left (bottom-aligned), members right -->
+      <!-- Header + CTAs + two text boxes: left column -->
       <div class="grid gap-10 lg:grid-cols-2 lg:gap-14">
-        <!-- Left: text boxes pushed to bottom of grid row -->
-        <div class="flex flex-col justify-end gap-5">
+        <!-- Left: eyebrow, title, CTAs, then text boxes -->
+        <div class="flex flex-col gap-6">
+          <div>
+            <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">GSF Committee</p>
+            <h2 class="mb-5 text-2xl font-extrabold text-white md:text-3xl lg:text-4xl">Green AI Committee</h2>
+            <div class="flex flex-wrap gap-3">
+              <a
+                href="#submission-form"
+                class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
+              >
+                GSF Academic Members can join the Green AI Committee →
+              </a>
+              <a
+                href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
+                class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
+              >
+                EU AI Act analysis →
+              </a>
+            </div>
+          </div>
           <div class="rounded-2xl bg-white/10 p-6">
             <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">Policy &amp; Standards</p>
             <p class="text-base leading-relaxed text-white/90">

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -668,16 +668,33 @@ const membershipBenefits = [
         <span class="text-primary">Powered by the Harmony Tool</span>
       </h2>
 
-      <div class="mt-6 max-w-3xl rounded-2xl border border-accent-lighter bg-accent-lightest-2 p-6">
-        <p class="text-base leading-relaxed text-primary-dark">
-          GSF Assemblies are structured, AI-facilitated working groups through which new standards and specifications are developed — from blank-page problem statement through to ratified output. The <strong>Harmony</strong> tool accelerates the consensus process: 14 experts, 15 organisations, and full agreement in 10 weeks is already a proven result. Each Assembly below represents an active research area where academic expertise can directly shape the standard from its foundations.
-        </p>
-        <a
-          href="https://greensoftware.foundation/assemblies/"
-          class="mt-4 inline-flex items-center text-sm font-semibold text-primary hover:underline"
-        >
-          About GSF Assemblies →
-        </a>
+      <div class="mt-6 grid gap-8 lg:grid-cols-[1fr_auto] lg:items-start">
+        <div class="rounded-2xl border border-accent-lighter bg-accent-lightest-2 p-6 lg:p-8">
+          <p class="text-base leading-relaxed text-primary-dark">
+            GSF Assemblies give your research a direct route into the standards process. Each Assembly is a structured, AI-facilitated working group where you bring your methodology and expertise — and the <strong>Harmony</strong> tool builds consensus around it alongside industry practitioners who will deploy the output.
+          </p>
+          <p class="mt-4 text-base leading-relaxed text-primary-dark">
+            The process is genuinely collaborative: you contribute your academic rigour and help shape the specification from its foundations — not reviewing a draft after the fact. When an Assembly reaches consensus, the output is ratified as a GSF standard, often progressing to ISO certification. Your contribution becomes part of the standard, not just cited by it.
+          </p>
+          <p class="mt-4 text-base leading-relaxed text-primary-dark">
+            Harmony accelerates this: in one recent Assembly, 14 experts from 15 organisations reached full consensus in 10 weeks. The same infrastructure — and the same seat at the table — is available to academic institutions engaging through GSF.
+          </p>
+        </div>
+
+        <div class="flex flex-col items-center gap-4 rounded-2xl border border-primary/20 bg-primary/5 p-6 text-center lg:w-56 lg:shrink-0">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-primary">
+            <svg class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          </div>
+          <p class="text-sm font-semibold text-primary-dark">Join an active Assembly and shape the next GSF standard from the ground up.</p>
+          <a
+            href="https://greensoftware.foundation/assemblies/"
+            class="w-full rounded-lg bg-primary px-5 py-3 text-sm font-bold text-white transition-colors hover:bg-primary-dark"
+          >
+            Explore GSF Assemblies
+          </a>
+        </div>
       </div>
 
       <p class="mt-8 text-sm text-gray-darker">Active initiatives feeding into the standards pipeline — where academic collaboration is being actively sought.</p>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -884,8 +884,17 @@ const membershipBenefits = [
         </div>
       </div>
 
-      <p class="mt-10 text-center text-base font-semibold text-primary-dark">
-        Academic engagement within the GSF is established, not experimental.
+    </div>
+  </section>
+
+  <!-- Statement Banner -->
+  <section class="bg-primary py-16 md:py-20">
+    <div class="container">
+      <p class="text-center text-3xl font-extrabold leading-tight text-white md:text-4xl lg:text-5xl">
+        Academic engagement within the GSF is{" "}
+        <span class="text-accent">established</span>,{" "}
+        not{" "}
+        <span class="text-accent">experimental</span>
       </p>
     </div>
   </section>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -186,6 +186,29 @@ const membershipBenefits = [
     bgClass="bg-accent-lightest-2"
   />
 
+  <!-- Academic member logos (directly below hero) -->
+  {academicLogos.length > 0 ? (
+    <LogoMarquee
+      heading="Institutions already working with the Green Software Foundation"
+      logos={academicLogos}
+      bgClass="bg-white"
+      fadeBgClass="from-white"
+      directoryHref="/membership/"
+      directoryText="About membership"
+    />
+  ) : (
+    <section class="bg-white py-10 md:py-12">
+      <div class="container">
+        <p class="mb-4 text-center text-sm font-medium text-gray-darker">
+          Institutions already working with the Green Software Foundation
+        </p>
+        <p class="text-center text-base font-semibold text-primary-dark">
+          Chalmers University of Technology · Concordia University · University College London · University of Amsterdam · University of Bristol · University of Edinburgh · Manchester Metropolitan University · Texas State University
+        </p>
+      </div>
+    </section>
+  )}
+
   <!-- Bridge section: GSF's unique position -->
   <section class="bg-primary py-14 md:py-20">
     <div class="container">
@@ -208,14 +231,14 @@ const membershipBenefits = [
         <!-- Statement text -->
         <div class="text-center">
           <p class="text-xl font-extrabold leading-snug text-white md:text-2xl lg:text-3xl">
-            GSF is where a computer science department's measurement methodology research connects directly to the ESG reporting reality of a Fortune 500 company implementing it next quarter.
+            GSF is where a computer science department's measurement methodology research <span class="text-accent">connects directly</span> to the ESG reporting reality of a Fortune 500 company implementing it next quarter.
           </p>
           <p class="mt-4 text-base font-semibold text-white/70 md:text-lg">
-            No other organisation holds both sides of that relationship simultaneously.
+            That structural position — trusted by research institutions and industry organisations simultaneously — is what makes the work possible.
           </p>
           <div class="mx-auto mt-8 h-px w-16 bg-white/20"></div>
           <p class="mx-auto mt-8 max-w-2xl text-base leading-relaxed text-white/80 md:text-lg">
-            GSF convenes the industry members who need answers and the research institutions who develop them — and provides the governance infrastructure to turn that collaboration into ratified, ISO-certified standards.
+            Within the Foundation, industry organisations bring specific, unsolved challenges. Research institutions bring the methodology to address them. GSF provides the governance structure to make that exchange productive — turning collaboration into co-authored white papers, technical reports, and ratified ISO standards that the industry deploys at scale.
           </p>
         </div>
       </div>
@@ -430,29 +453,6 @@ const membershipBenefits = [
       </p>
     </div>
   </section>
-
-  <!-- Academic member logos -->
-  {academicLogos.length > 0 ? (
-    <LogoMarquee
-      heading="Institutions already working with the Green Software Foundation"
-      logos={academicLogos}
-      bgClass="bg-accent-lightest-2"
-      fadeBgClass="from-accent-lightest-2"
-      directoryHref="/membership/"
-      directoryText="About membership"
-    />
-  ) : (
-    <section class="bg-accent-lightest-2 py-10 md:py-12">
-      <div class="container">
-        <p class="mb-4 text-center text-sm font-medium text-gray-darker">
-          Institutions already working with the Green Software Foundation
-        </p>
-        <p class="text-center text-base font-semibold text-primary-dark">
-          Chalmers University of Technology · Concordia University · University College London · University of Amsterdam · University of Bristol · University of Edinburgh · Manchester Metropolitan University · Texas State University
-        </p>
-      </div>
-    </section>
-  )}
 
   <!-- Section 7: Submission Form -->
   <section id="submission-form" class="bg-white py-16 md:py-20">

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -48,37 +48,37 @@ const workingOnCards = [
 const engagementForms = [
   {
     title: "Co-authorship",
-    body: "on white papers and technical guidance aligned with GSF standards — research that reaches the organisations implementing it, not only those reading it.",
+    body: "On white papers and technical guidance aligned with GSF standards — research that reaches the organisations implementing it, not only those reading it.",
     buttonText: "Published Papers",
     buttonHref: "https://greensoftware.foundation/policy/research/",
   },
   {
     title: "Assembly participation",
-    body: "via GSF's Harmony platform — the AI-facilitated consensus mechanism through which standards are shaped from blank-page problem statement to ratified specification; academic voices participate in the process, not just the output.",
-    buttonText: "View Past Hackathons",
-    buttonHref: "https://hack.greensoftware.foundation/",
+    body: "Via GSF's Harmony platform — the AI-facilitated consensus mechanism through which standards are shaped from blank-page problem statement to ratified specification. Academic voices participate in the process, not just the output.",
+    buttonText: "About GSF Assemblies",
+    buttonHref: "https://greensoftware.foundation/assemblies/",
   },
   {
     title: "Structured introductions",
-    body: "to specific GSF member organisations where a research project aligns with an active member challenge — subject to Policy Working Group review and approval.",
+    body: "To specific GSF member organisations where a research project aligns with an active member challenge — subject to Policy Working Group review and approval.",
     buttonText: "GSF Membership Governance",
     buttonHref: "https://greensoftware.foundation/governance/",
   },
   {
     title: "Named researcher recognition",
-    body: "in GSF publications and communications — providing evidence of real-world impact, a publication route, and a named industry partner.",
+    body: "In GSF publications and communications — providing evidence of real-world impact, a publication route, and a named industry partner.",
     buttonText: "Published Papers",
     buttonHref: "https://greensoftware.foundation/policy/research/",
   },
   {
     title: "Hackathon & event participation",
-    body: ", including the annual Carbon Hack, providing applied research opportunities with direct industry involvement.",
+    body: "Including the annual Carbon Hack, providing applied research opportunities with direct industry involvement.",
     buttonText: "GSF Past Hackathons",
     buttonHref: "https://hack.greensoftware.foundation/",
   },
   {
     title: "Formal academic membership",
-    body: "— available at no cost — as the collaboration matures and alignment with GSF's mission is established.",
+    body: "Available at no cost as the collaboration matures and alignment with GSF's mission is established.",
     buttonText: "Submit your interest",
     buttonHref: "#submission-form",
   },
@@ -221,7 +221,7 @@ const membershipBenefits = [
     <div class="container">
       <h2 class="text-center text-2xl font-semibold md:text-3xl lg:text-4xl">Forms of Engagement</h2>
       <p class="mx-auto mt-4 max-w-2xl text-center text-base leading-relaxed text-primary-dark md:text-lg">
-        Engagement with the Green Software Foundation is not a single pathway. The following forms have emerged from real collaborations.
+        Engagement with GSF is not a single pathway. The following forms have emerged from real collaborations.
       </p>
       <div class="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
         {engagementForms.map((item) => (
@@ -231,7 +231,7 @@ const membershipBenefits = [
             <div class="mt-5">
               <a
                 href={item.buttonHref}
-                class="inline-block rounded-lg bg-primary px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-primary-dark"
+                class="inline-block rounded-lg border border-primary px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary hover:text-white"
               >
                 {item.buttonText}
               </a>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -585,8 +585,8 @@ const membershipBenefits = [
   <!-- Full member logo marquee -->
   <LogoMarquee
     heading="GSF member organisations"
-    bgClass="bg-accent-lightest-2"
-    fadeBgClass="from-accent-lightest-2"
+    bgClass="bg-white"
+    fadeBgClass="from-white"
     directoryHref="https://directory.greensoftware.foundation/members/"
     directoryText="View all members"
   />
@@ -656,26 +656,44 @@ const membershipBenefits = [
         </div>
       </div>
 
-      <!-- Future Research via GSF Assemblies -->
-      <div class="mt-10">
-        <div class="mb-6 flex items-center gap-4">
-          <h3 class="shrink-0 text-base font-extrabold uppercase tracking-wide text-primary-dark">Future Research via GSF Assemblies Powered by the Harmony Tool</h3>
-          <div class="h-px flex-1 bg-accent-lighter"></div>
-        </div>
-        <p class="mb-6 text-sm text-gray-darker">Active initiatives feeding into the standards pipeline — where academic collaboration is being actively sought.</p>
-        <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {crossCuttingAreas.map((item) => (
-            <div class="flex flex-col rounded-lg border border-dashed border-accent-lighter bg-white/60 p-5">
-              <h4 class="text-base font-bold text-primary-dark">{item.title}</h4>
-              <p class="mt-2 flex-1 text-sm leading-relaxed text-gray-darker">{item.description}</p>
-              {item.link && (
-                <a href={item.link} class="mt-3 inline-flex items-center text-sm font-semibold text-primary hover:underline">
-                  {item.linkText} →
-                </a>
-              )}
-            </div>
-          ))}
-        </div>
+    </div>
+  </section>
+
+  <!-- Future Research via GSF Assemblies — standalone section -->
+  <section class="bg-white py-16 md:py-20">
+    <div class="container">
+      <p class="mb-3 text-xs font-bold uppercase tracking-widest text-primary">Active Initiatives</p>
+      <h2 class="text-2xl font-extrabold md:text-3xl lg:text-4xl">
+        Future Research via GSF Assemblies<br class="hidden sm:block" />
+        <span class="text-primary">Powered by the Harmony Tool</span>
+      </h2>
+
+      <div class="mt-6 max-w-3xl rounded-2xl border border-accent-lighter bg-accent-lightest-2 p-6">
+        <p class="text-base leading-relaxed text-primary-dark">
+          GSF Assemblies are structured, AI-facilitated working groups through which new standards and specifications are developed — from blank-page problem statement through to ratified output. The <strong>Harmony</strong> tool accelerates the consensus process: 14 experts, 15 organisations, and full agreement in 10 weeks is already a proven result. Each Assembly below represents an active research area where academic expertise can directly shape the standard from its foundations.
+        </p>
+        <a
+          href="https://greensoftware.foundation/assemblies/"
+          class="mt-4 inline-flex items-center text-sm font-semibold text-primary hover:underline"
+        >
+          About GSF Assemblies →
+        </a>
+      </div>
+
+      <p class="mt-8 text-sm text-gray-darker">Active initiatives feeding into the standards pipeline — where academic collaboration is being actively sought.</p>
+
+      <div class="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {crossCuttingAreas.map((item) => (
+          <div class="flex flex-col rounded-lg border border-dashed border-primary/30 bg-primary/5 p-5">
+            <h3 class="text-base font-bold text-primary-dark">{item.title}</h3>
+            <p class="mt-2 flex-1 text-sm leading-relaxed text-gray-darker">{item.description}</p>
+            {item.link && (
+              <a href={item.link} class="mt-3 inline-flex items-center text-sm font-semibold text-primary hover:underline">
+                {item.linkText} →
+              </a>
+            )}
+          </div>
+        ))}
       </div>
     </div>
   </section>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -205,35 +205,40 @@ const hardwareStandards = [
 
 const crossCuttingAreas = [
   {
-    title: "SCI for Games",
+    title: "Reducing Carbon in the Gaming Industry",
+    assemblyName: "SCI for Games",
     description:
       "The gaming industry is one of the largest and fastest-growing software sectors by energy consumption, yet no standardised methodology exists for measuring its carbon intensity. This GSF Assembly, developed in partnership with the Sustainable Games Alliance, is working to extend SCI to cover game software — defining the measurement boundaries, functional units, and data sources that reflect how games are developed, distributed, and played.",
     link: "/assemblies/",
     linkText: "Register your interest in the assembly",
   },
   {
-    title: "SCI for OpenTelemetry",
+    title: "Making Carbon a First-Class Signal in Software Observability",
+    assemblyName: "SCI for OpenTelemetry",
     description:
       "Engineering teams routinely instrument software with observability tooling to monitor performance and reliability — but carbon intensity is absent from those signals. This assembly is developing a methodology to integrate SCI measurement directly into OpenTelemetry tooling, enabling teams to surface carbon data alongside latency and error rates within their existing observability stacks.",
     link: "/assemblies/",
     linkText: "Register your interest in the assembly",
   },
   {
-    title: "SCI for Automotive",
+    title: "Measuring Software Carbon Across the Vehicle Lifecycle",
+    assemblyName: "SCI for Automotive",
     description:
       "Software in modern vehicles spans a wide range of systems — from embedded control units to cloud-connected services — yet no standard methodology exists for measuring its carbon intensity across the full vehicle lifecycle. This assembly is applying SCI methodology to automotive software, defining how to calculate carbon intensity across the hardware and connectivity boundaries of a modern vehicle.",
     link: "/assemblies/",
     linkText: "Register your interest in the assembly",
   },
   {
-    title: "SCI Disclosure Certification",
+    title: "Bridging Carbon Measurement into ESG and Regulatory Disclosure",
+    assemblyName: "SCI Disclosure Certification",
     description:
       "Voluntary structured self-reporting programme under development. Bridges SCI into ESG and CSRD disclosure workflows — providing a certification pathway for organisations that want to demonstrate SCI compliance in regulatory reporting.",
     link: "https://greensoftware.foundation/standards/certification/",
     linkText: "View certification programme",
   },
   {
-    title: "Hardware–Software Interoperability for Data Centre Sustainability",
+    title: "Closing the Gap Between Hardware Efficiency and Software Workload Decisions",
+    assemblyName: "Hardware–Software Interoperability for Data Centre Sustainability",
     description:
       "Sitting at the intersection of hardware efficiency standards and operational data centre practice, this assembly addresses a critical gap: hardware-level efficiency metrics and software-level workload decisions are currently optimised in isolation. The goal is a shared framework that enables data centre operators to align workload scheduling with real-time energy and cooling constraints.",
     link: "/assemblies/hardware-software-interoperability-for-data-centre-sustainability/",
@@ -676,6 +681,9 @@ const membershipBenefits = [
         {crossCuttingAreas.map((item) => (
           <div class="flex flex-col rounded-lg border border-dashed border-primary/30 bg-primary/5 p-5">
             <h3 class="text-base font-bold text-primary-dark">{item.title}</h3>
+            {item.assemblyName && (
+              <p class="mt-1 text-xs font-semibold uppercase tracking-wide text-primary/70">{item.assemblyName}</p>
+            )}
             <p class="mt-2 flex-1 text-sm leading-relaxed text-gray-darker">{item.description}</p>
             {item.link && (
               <a href={item.link} class="mt-3 inline-flex items-center text-sm font-semibold text-primary hover:underline">

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -245,19 +245,45 @@ const membershipBenefits = [
     </div>
   </section>
 
-  <!-- Section 2: The Convening Model -->
-  <section class="bg-white py-16 md:py-24">
+  <!-- Section 2: Forms of Engagement -->
+  <section class="bg-white py-16 md:py-20">
+    <div class="container">
+      <h2 class="text-center text-2xl font-semibold md:text-3xl lg:text-4xl">Forms of Engagement</h2>
+      <p class="mx-auto mt-4 max-w-2xl text-center text-base leading-relaxed text-primary-dark md:text-lg">
+        Engagement with GSF is not a single pathway. The following forms have emerged from real collaborations.
+      </p>
+      <div class="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {engagementForms.map((item) => (
+          <div class="flex flex-col rounded-xl border bg-accent-lightest-2 p-6">
+            <h3 class="text-lg font-extrabold text-primary-dark">{item.title}</h3>
+            <p class="mt-3 flex-1 text-base leading-relaxed text-primary-dark">{item.body}</p>
+            <div class="mt-5">
+              <a
+                href={item.buttonHref}
+                class="inline-block rounded-lg border border-primary px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary hover:text-white"
+              >
+                {item.buttonText}
+              </a>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: The Convening Model -->
+  <section class="bg-accent-lightest-2 py-16 md:py-24">
     <div class="container">
       <p class="mb-3 text-center text-xs font-bold uppercase tracking-widest text-primary">How It Works</p>
       <h2 class="text-center text-2xl font-extrabold md:text-3xl lg:text-4xl">The Convening <span class="text-primary">Model</span></h2>
 
       <div class="mx-auto mt-8 grid max-w-5xl gap-6 md:grid-cols-2 md:gap-10">
-        <div class="rounded-2xl border border-accent-lighter bg-accent-lightest-2 p-6 md:p-8">
+        <div class="rounded-2xl border border-accent-lighter bg-white p-6 md:p-8">
           <p class="text-base leading-relaxed text-primary-dark">
             GSF operates at the intersection of two populations that rarely meet with the right structure in place: industry organisations with specific, unsolved green software problems — and research institutions with the methodology and rigour to address them.
           </p>
         </div>
-        <div class="rounded-2xl border border-accent-lighter bg-accent-lightest-2 p-6 md:p-8">
+        <div class="rounded-2xl border border-accent-lighter bg-white p-6 md:p-8">
           <p class="text-base leading-relaxed text-primary-dark">
             The Foundation's role is to hold the network, run the matching process, and provide the governance infrastructure through which collaboration becomes output — a white paper, a co-authored technical report, or a ratified specification that changes how the industry reduces software carbon.
           </p>
@@ -287,37 +313,21 @@ const membershipBenefits = [
           ))}
         </div>
 
-        <div class="mt-8 rounded-xl border-l-4 border-primary bg-accent-lightest-2 px-5 py-4">
-          <p class="text-sm text-gray-darker">
-            There is no guaranteed outcome from submission. All substantive proposals receive a considered review, and the process has genuine governance integrity — decisions are made collectively, not by a single point of contact.
-          </p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Section 3: Forms of Engagement (moved above What Our Members Are Working On) -->
-  <section class="bg-accent-lightest-2 py-16 md:py-20">
-    <div class="container">
-      <h2 class="text-center text-2xl font-semibold md:text-3xl lg:text-4xl">Forms of Engagement</h2>
-      <p class="mx-auto mt-4 max-w-2xl text-center text-base leading-relaxed text-primary-dark md:text-lg">
-        Engagement with GSF is not a single pathway. The following forms have emerged from real collaborations.
-      </p>
-      <div class="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-        {engagementForms.map((item) => (
-          <div class="flex flex-col rounded-xl border bg-white p-6">
-            <h3 class="text-lg font-extrabold text-primary-dark">{item.title}</h3>
-            <p class="mt-3 flex-1 text-base leading-relaxed text-primary-dark">{item.body}</p>
-            <div class="mt-5">
-              <a
-                href={item.buttonHref}
-                class="inline-block rounded-lg border border-primary px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary hover:text-white"
-              >
-                {item.buttonText}
-              </a>
+        <div class="mt-10 rounded-2xl bg-white p-6 shadow-sm md:p-8">
+          <div class="flex gap-4">
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
+              <svg class="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+              </svg>
+            </div>
+            <div>
+              <p class="text-sm font-bold text-primary-dark">A transparent, collective process</p>
+              <p class="mt-2 text-sm leading-relaxed text-gray-darker">
+                There is no guaranteed outcome from submission. Every substantive proposal receives a considered review — and decisions are made collectively by the Policy Working Group, not by a single point of contact. The process has genuine governance integrity.
+              </p>
             </div>
           </div>
-        ))}
+        </div>
       </div>
     </div>
   </section>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -207,17 +207,23 @@ const crossCuttingAreas = [
   {
     title: "SCI for Games",
     description:
-      "Joint GSF and Sustainable Games Alliance initiative launched March 2026. Applies SCI measurement methodology to the gaming industry — a high-energy sector with limited existing sustainability metrics.",
+      "The gaming industry is one of the largest and fastest-growing software sectors by energy consumption, yet no standardised methodology exists for measuring its carbon intensity. This GSF Assembly, developed in partnership with the Sustainable Games Alliance, is working to extend SCI to cover game software — defining the measurement boundaries, functional units, and data sources that reflect how games are developed, distributed, and played.",
+    link: "/assemblies/",
+    linkText: "Register your interest in the assembly",
   },
   {
     title: "SCI for OpenTelemetry",
     description:
-      "Assembly-in-formation linking SCI measurement to OTel observability tooling, with Goldman Sachs as assembly champion. Research need: integrating carbon intensity signals into existing engineering observability stacks.",
+      "Engineering teams routinely instrument software with observability tooling to monitor performance and reliability — but carbon intensity is absent from those signals. This assembly is developing a methodology to integrate SCI measurement directly into OpenTelemetry tooling, enabling teams to surface carbon data alongside latency and error rates within their existing observability stacks.",
+    link: "/assemblies/",
+    linkText: "Register your interest in the assembly",
   },
   {
-    title: "SCI for Automotive (ECUs / LCA)",
+    title: "SCI for Automotive",
     description:
-      "Exploratory thread with Volvo applying SCI methodology to embedded software in vehicles. Addresses lifecycle carbon assessment for automotive ECU software — a domain where academic expertise in embedded systems and LCA methodology is directly applicable.",
+      "Software in modern vehicles spans a wide range of systems — from embedded control units to cloud-connected services — yet no standard methodology exists for measuring its carbon intensity across the full vehicle lifecycle. This assembly is applying SCI methodology to automotive software, defining how to calculate carbon intensity across the hardware and connectivity boundaries of a modern vehicle.",
+    link: "/assemblies/",
+    linkText: "Register your interest in the assembly",
   },
   {
     title: "SCI Disclosure Certification",
@@ -232,7 +238,7 @@ const crossCuttingAreas = [
   {
     title: "Hardware–Software Interoperability for Data Centre Sustainability",
     description:
-      "Assembly seeded by Zutacore, sitting at the intersection of WDPC and operational data centre practice. Addresses the gap between hardware-level efficiency metrics and software-level workload decisions.",
+      "Sitting at the intersection of hardware efficiency standards and operational data centre practice, this assembly addresses a critical gap: hardware-level efficiency metrics and software-level workload decisions are currently optimised in isolation. The goal is a shared framework that enables data centre operators to align workload scheduling with real-time energy and cooling constraints.",
   },
 ];
 
@@ -631,9 +637,14 @@ const membershipBenefits = [
         <p class="mb-6 text-sm text-gray-darker">Active initiatives feeding into the standards pipeline — where academic collaboration is being actively sought.</p>
         <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
           {crossCuttingAreas.map((item) => (
-            <div class="rounded-lg border border-dashed border-accent-lighter bg-white/60 p-5">
+            <div class="flex flex-col rounded-lg border border-dashed border-accent-lighter bg-white/60 p-5">
               <h4 class="text-base font-bold text-primary-dark">{item.title}</h4>
-              <p class="mt-2 text-sm leading-relaxed text-gray-darker">{item.description}</p>
+              <p class="mt-2 flex-1 text-sm leading-relaxed text-gray-darker">{item.description}</p>
+              {item.link && (
+                <a href={item.link} class="mt-3 inline-flex items-center text-sm font-semibold text-primary hover:underline">
+                  {item.linkText} →
+                </a>
+              )}
             </div>
           ))}
         </div>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -762,10 +762,32 @@ const membershipBenefits = [
             <p class="shrink-0 text-xs font-bold uppercase tracking-widest text-white/50">Committee Members</p>
             <div class="h-px flex-1 bg-white/20"></div>
           </div>
+
+          <!-- Co-chairs: featured, larger cards -->
+          <div class="mb-3 grid gap-3 sm:grid-cols-2">
+            {committeeWithLogos.filter((m) => m.role === "Co-Chair").map((member) => (
+              <div class="flex flex-col items-center gap-3 rounded-xl bg-white p-5 text-center">
+                <div class="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-xl p-1">
+                  {member.logo ? (
+                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
+                  ) : (
+                    <span class="text-xl font-extrabold text-primary">{member.initials}</span>
+                  )}
+                </div>
+                <div>
+                  <span class="mb-1 inline-block rounded-full bg-accent px-2.5 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
+                  <p class="text-sm font-extrabold leading-tight text-primary-dark">{member.name}</p>
+                  <p class="mt-0.5 text-xs text-gray-darker">{member.org}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <!-- Regular members: compact 2-col grid -->
           <div class="grid gap-3 sm:grid-cols-2">
-            {committeeWithLogos.map((member) => (
+            {committeeWithLogos.filter((m) => m.role !== "Co-Chair").map((member) => (
               <div class="flex items-center gap-3 rounded-xl bg-white p-4">
-                <div class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-accent-lightest-2 p-1.5">
+                <div class="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-lg p-1">
                   {member.logo ? (
                     <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
                   ) : (
@@ -775,9 +797,6 @@ const membershipBenefits = [
                 <div class="min-w-0">
                   <p class="text-sm font-extrabold leading-tight text-primary-dark">{member.name}</p>
                   <p class="mt-0.5 truncate text-xs text-gray-darker">{member.org}</p>
-                  {member.role === "Co-Chair" && (
-                    <span class="mt-1 inline-block rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
-                  )}
                 </div>
               </div>
             ))}

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -315,6 +315,42 @@ const researchProgramme = [
   },
 ];
 
+const greenAICommitteeMembers = [
+  { name: "Sanjay Podder", org: "Accenture", role: "Co-Chair" },
+  { name: "Thomas Lewis", org: "Microsoft", role: "Co-Chair" },
+  { name: "Arun Ravindran", org: "BCG", role: "Member" },
+  { name: "Chris Xie", org: "Futurewei", role: "Member" },
+  { name: "Federica Sarro", org: "UCL", role: "Member" },
+  { name: "Gadhu Sundaram", org: "NTT Data", role: "Member" },
+  { name: "Juan José Lopez Murphy", org: "Globant", role: "Member" },
+  { name: "Nadim Kapadia", org: "HSBC", role: "Member" },
+  { name: "Nisha Menon", org: "Siemens", role: "Member" },
+  { name: "Savannah Goodman", org: "Google", role: "Member" },
+  { name: "Vincent Caldeira", org: "IBM / Red Hat", role: "Member" },
+  { name: "Vinjosh Varghese", org: "UBS", role: "Member" },
+];
+
+const committeeWithLogos = greenAICommitteeMembers.map((member) => {
+  const matched = (membersData as any[]).find((m: any) => {
+    if (!m.active || !m.logo || m.hideLogo) return false;
+    const mName = (m.companyName || "").toLowerCase();
+    const orgLower = member.org.toLowerCase();
+    return mName.includes(orgLower) || orgLower.includes(mName);
+  });
+  const initials = member.name
+    .split(" ")
+    .filter(Boolean)
+    .map((w: string) => w[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+  return {
+    ...member,
+    logo: matched ? `/assets/${matched.logo}` : null,
+    initials,
+  };
+});
+
 const membershipBenefits = [
   {
     title: "Named industry partnerships",
@@ -652,13 +688,13 @@ const membershipBenefits = [
   <!-- Green AI Committee full-width section -->
   <section class="bg-primary py-16 md:py-20">
     <div class="container">
-      <div class="mx-auto max-w-4xl">
+      <div class="mx-auto max-w-5xl">
         <p class="mb-4 text-xs font-bold uppercase tracking-widest text-accent">GSF Committee</p>
         <h2 class="text-2xl font-extrabold text-white md:text-3xl lg:text-4xl">Green AI Committee</h2>
-        <p class="mt-6 text-base leading-relaxed text-white/90 md:text-lg">
+        <p class="mt-6 max-w-3xl text-base leading-relaxed text-white/90 md:text-lg">
           The Green AI Committee is GSF's dedicated policy and standards body responding to EU AI Act obligations — and was an active contributor to the SCI for AI ratification process. It coordinates GSF's collective technical response to AI environmental regulation across member organisations, translating industry deployment realities into policy positions that regulators can act on.
         </p>
-        <p class="mt-4 text-base leading-relaxed text-white/90 md:text-lg">
+        <p class="mt-4 max-w-3xl text-base leading-relaxed text-white/90 md:text-lg">
           For academic researchers working at the intersection of AI, environmental assessment, and regulatory compliance, the Green AI Committee is the point of engagement — connecting academic expertise directly to the policy and standards processes where it carries weight.
         </p>
         <div class="mt-8 flex flex-wrap gap-4">
@@ -674,6 +710,55 @@ const membershipBenefits = [
           >
             Express your interest →
           </a>
+        </div>
+
+        <!-- Committee Members -->
+        <div class="mt-14">
+          <div class="mb-8 flex items-center gap-4">
+            <p class="shrink-0 text-xs font-bold uppercase tracking-widest text-white/50">Committee Members</p>
+            <div class="h-px flex-1 bg-white/20"></div>
+          </div>
+
+          <!-- Co-chairs featured row -->
+          <div class="mb-6 grid gap-4 sm:grid-cols-2">
+            {committeeWithLogos.filter(m => m.role === "Co-Chair").map((member) => (
+              <div class="flex items-center gap-4 rounded-xl border border-accent/40 bg-white/10 p-4 backdrop-blur-sm">
+                <div class="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white">
+                  {member.logo ? (
+                    <img src={member.logo} alt={member.org} class="h-10 w-10 object-contain" loading="lazy" decoding="async" />
+                  ) : (
+                    <span class="text-lg font-extrabold text-primary">{member.initials}</span>
+                  )}
+                </div>
+                <div class="min-w-0">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="text-sm font-extrabold text-white">{member.name}</p>
+                    <span class="rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
+                  </div>
+                  <p class="mt-0.5 text-xs text-white/60">{member.org}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <!-- Regular members grid -->
+          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {committeeWithLogos.filter(m => m.role !== "Co-Chair").map((member) => (
+              <div class="flex items-center gap-3 rounded-xl bg-white/10 p-3.5">
+                <div class="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white">
+                  {member.logo ? (
+                    <img src={member.logo} alt={member.org} class="h-7 w-7 object-contain" loading="lazy" decoding="async" />
+                  ) : (
+                    <span class="text-xs font-extrabold text-primary">{member.initials}</span>
+                  )}
+                </div>
+                <div class="min-w-0">
+                  <p class="truncate text-sm font-semibold leading-tight text-white">{member.name}</p>
+                  <p class="truncate text-xs text-white/50">{member.org}</p>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -4,8 +4,19 @@ import { navItems } from "@/lib/nav-items";
 
 import Navbar from "@/components/navbar.astro";
 import Hero from "@/components/hero.astro";
+import LogoMarquee from "@/components/logo-marquee.astro";
 import Footer from "@/components/footer.astro";
 import Testimonial from "@/components/testimonial.astro";
+
+import membersData from "@/data/members.json";
+const academicLogos = (membersData as any[])
+  .filter((m: any) => m.active && m.logo && !m.hideLogo && m.organisationType === "Academia")
+  .sort((a: any, b: any) => a.companyName.localeCompare(b.companyName))
+  .map((m: any) => ({
+    name: m.companyName,
+    logo: `/assets/${m.logo}`,
+    website: m.companyWebsite || "greensoftware.foundation",
+  }));
 
 const heroBody = [
   "The Green Software Foundation is where a computer science department's measurement methodology research connects directly to the ESG reporting reality of a Fortune 500 company implementing it next quarter. No other organisation holds both sides of that relationship simultaneously.",
@@ -130,19 +141,23 @@ const standardsItems = [
 const membershipBenefits = [
   {
     title: "Named industry partnerships",
-    body: "structured connections to GSF member organisations working on adjacent challenges, providing the industry-linked research context that EU Horizon, UKRI, and NSF funding applications increasingly require.",
+    body: "Structured connections to GSF member organisations working on adjacent challenges, providing the industry-linked research context that EU Horizon, UKRI, and NSF funding applications increasingly require.",
+    icon: "leading-icon.svg",
   },
   {
     title: "Publication routes",
-    body: "co-authorship credit on GSF technical reports, reviewed by the relevant Assembly and released publicly; a route to work that is read by the organisations deploying it, not only the academics citing it.",
+    body: "Co-authorship credit on GSF technical reports, reviewed by the relevant Assembly and released publicly — a route to work that is read by the organisations deploying it, not only the academics citing it.",
+    icon: "standardized-icon.svg",
   },
   {
     title: "Evidence of real-world impact",
-    body: "GSF standards are ISO-certified and in active deployment across banking, technology, and infrastructure; research that contributes to them produces the impact evidence that determines career progression and institutional research rankings.",
+    body: "GSF standards are ISO-certified and in active deployment across banking, technology, and infrastructure. Research that contributes to them produces the impact evidence that determines career progression and institutional research rankings.",
+    icon: "realtime-icon.svg",
   },
   {
     title: "Peer network access",
-    body: "participation in working groups, Assemblies, and GSF events alongside the member organisations deploying green software at scale.",
+    body: "Participation in working groups, Assemblies, and GSF events alongside the member organisations deploying green software at scale.",
+    icon: "co2-icon.svg",
   },
 ];
 ---
@@ -335,35 +350,80 @@ const membershipBenefits = [
   </section>
 
   <!-- Section 6: Academic Membership -->
-  <section class="bg-white py-16 md:py-20">
+  <section class="bg-white py-16 md:py-24">
     <div class="container">
-      <div class="mx-auto max-w-3xl">
-        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Academic Membership</h2>
-        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
-          Academic membership in the Green Software Foundation is the formal relationship that follows substantive engagement when research and mission are genuinely aligned.
-        </p>
-        <ul class="mt-6 space-y-4">
-          {membershipBenefits.map((item) => (
-            <li class="text-base leading-relaxed text-primary-dark">
-              <span class="font-bold">{item.title}</span> — {item.body}
-            </li>
-          ))}
-        </ul>
-        <p class="mt-6 text-sm text-gray-darker">
-          Academic membership is available at no cost for qualifying institutions. Membership decisions are made at the Policy Working Group level.
-        </p>
-        <p class="mt-6 text-base text-primary-dark">
-          <span class="font-semibold">Current academic members:</span>{" "}Chalmers University of Technology · Concordia University · University College London · University of Amsterdam · University of Bristol · University of Edinburgh · Manchester Metropolitan University · Texas State University
-        </p>
-        <p class="mt-4 font-semibold text-primary-dark">
-          Academic engagement within the GSF is established, not experimental.
-        </p>
+      <p class="mb-3 text-center text-xs font-bold uppercase tracking-widest text-primary">Academic Membership</p>
+      <h2 class="text-center text-2xl font-extrabold md:text-3xl lg:text-4xl">
+        The formal relationship that follows <span class="text-primary">substantive engagement</span>
+      </h2>
+      <p class="mx-auto mt-5 max-w-2xl text-center text-base leading-relaxed text-primary-dark md:text-lg">
+        When research and mission are genuinely aligned, academic membership provides structured access to the network and governance infrastructure through which that alignment creates measurable real-world impact.
+      </p>
+
+      <div class="mt-12 grid gap-6 sm:grid-cols-2">
+        {membershipBenefits.map((item) => (
+          <div class="flex gap-4 rounded-xl border border-accent-lighter bg-accent-lightest-2 p-6">
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
+              <svg class="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <div>
+              <h3 class="text-base font-extrabold text-primary-dark">{item.title}</h3>
+              <p class="mt-1.5 text-sm leading-relaxed text-gray-darker">{item.body}</p>
+            </div>
+          </div>
+        ))}
       </div>
+
+      <div class="mx-auto mt-10 max-w-3xl rounded-2xl bg-primary p-6 text-white md:p-8">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p class="text-lg font-extrabold">Available at no cost for qualifying institutions</p>
+            <p class="mt-1 text-sm leading-relaxed text-white/80">
+              Membership decisions are made at the Policy Working Group level — collectively, not by a single point of contact.
+            </p>
+          </div>
+          <a
+            href="#submission-form"
+            class="inline-block shrink-0 rounded-lg bg-white px-5 py-2.5 text-sm font-bold text-primary transition-colors hover:bg-accent-lightest-2"
+          >
+            Submit a proposal →
+          </a>
+        </div>
+      </div>
+
+      <p class="mt-10 text-center text-base font-semibold text-primary-dark">
+        Academic engagement within the GSF is established, not experimental.
+      </p>
     </div>
   </section>
 
+  <!-- Academic member logos -->
+  {academicLogos.length > 0 ? (
+    <LogoMarquee
+      heading="Institutions already working with the Green Software Foundation"
+      logos={academicLogos}
+      bgClass="bg-accent-lightest-2"
+      fadeBgClass="from-accent-lightest-2"
+      directoryHref="/membership/"
+      directoryText="About membership"
+    />
+  ) : (
+    <section class="bg-accent-lightest-2 py-10 md:py-12">
+      <div class="container">
+        <p class="mb-4 text-center text-sm font-medium text-gray-darker">
+          Institutions already working with the Green Software Foundation
+        </p>
+        <p class="text-center text-base font-semibold text-primary-dark">
+          Chalmers University of Technology · Concordia University · University College London · University of Amsterdam · University of Bristol · University of Edinburgh · Manchester Metropolitan University · Texas State University
+        </p>
+      </div>
+    </section>
+  )}
+
   <!-- Section 7: Submission Form -->
-  <section id="submission-form" class="bg-accent-lightest-2 py-16 md:py-20">
+  <section id="submission-form" class="bg-white py-16 md:py-20">
     <div class="container">
       <div class="mx-auto max-w-2xl">
         <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Submit a Proposal</h2>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -229,11 +229,8 @@ const crossCuttingAreas = [
     title: "SCI Disclosure Certification",
     description:
       "Voluntary structured self-reporting programme under development. Bridges SCI into ESG and CSRD disclosure workflows — providing a certification pathway for organisations that want to demonstrate SCI compliance in regulatory reporting.",
-  },
-  {
-    title: "Green AI Committee",
-    description:
-      "Policy and standards body responding to EU AI Act obligations and active contributor to the SCI for AI ratification process. Coordinates GSF's technical response to AI environmental regulation across member organisations.",
+    link: "https://greensoftware.foundation/standards/certification/",
+    linkText: "View certification programme",
   },
   {
     title: "Hardware–Software Interoperability for Data Centre Sustainability",
@@ -647,6 +644,36 @@ const membershipBenefits = [
               )}
             </div>
           ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Green AI Committee full-width section -->
+  <section class="bg-primary py-16 md:py-20">
+    <div class="container">
+      <div class="mx-auto max-w-4xl">
+        <p class="mb-4 text-xs font-bold uppercase tracking-widest text-accent">GSF Committee</p>
+        <h2 class="text-2xl font-extrabold text-white md:text-3xl lg:text-4xl">Green AI Committee</h2>
+        <p class="mt-6 text-base leading-relaxed text-white/90 md:text-lg">
+          The Green AI Committee is GSF's dedicated policy and standards body responding to EU AI Act obligations — and was an active contributor to the SCI for AI ratification process. It coordinates GSF's collective technical response to AI environmental regulation across member organisations, translating industry deployment realities into policy positions that regulators can act on.
+        </p>
+        <p class="mt-4 text-base leading-relaxed text-white/90 md:text-lg">
+          For academic researchers working at the intersection of AI, environmental assessment, and regulatory compliance, the Green AI Committee is the point of engagement — connecting academic expertise directly to the policy and standards processes where it carries weight.
+        </p>
+        <div class="mt-8 flex flex-wrap gap-4">
+          <a
+            href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
+            class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
+          >
+            EU AI Act analysis →
+          </a>
+          <a
+            href="#submission-form"
+            class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
+          >
+            Express your interest →
+          </a>
         </div>
       </div>
     </div>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -49,26 +49,38 @@ const engagementForms = [
   {
     title: "Co-authorship",
     body: "on white papers and technical guidance aligned with GSF standards — research that reaches the organisations implementing it, not only those reading it.",
+    buttonText: "Published Papers",
+    buttonHref: "https://greensoftware.foundation/policy/research/",
   },
   {
     title: "Assembly participation",
     body: "via GSF's Harmony platform — the AI-facilitated consensus mechanism through which standards are shaped from blank-page problem statement to ratified specification; academic voices participate in the process, not just the output.",
+    buttonText: "View Past Hackathons",
+    buttonHref: "https://hack.greensoftware.foundation/",
   },
   {
     title: "Structured introductions",
     body: "to specific GSF member organisations where a research project aligns with an active member challenge — subject to Policy Working Group review and approval.",
+    buttonText: "GSF Membership Governance",
+    buttonHref: "https://greensoftware.foundation/governance/",
   },
   {
     title: "Named researcher recognition",
     body: "in GSF publications and communications — providing evidence of real-world impact, a publication route, and a named industry partner.",
+    buttonText: "Published Papers",
+    buttonHref: "https://greensoftware.foundation/policy/research/",
   },
   {
     title: "Hackathon & event participation",
     body: ", including the annual Carbon Hack, providing applied research opportunities with direct industry involvement.",
+    buttonText: "GSF Past Hackathons",
+    buttonHref: "https://hack.greensoftware.foundation/",
   },
   {
     title: "Formal academic membership",
     body: "— available at no cost — as the collaboration matures and alignment with GSF's mission is established.",
+    buttonText: "Submit your interest",
+    buttonHref: "#submission-form",
   },
 ];
 
@@ -212,14 +224,18 @@ const membershipBenefits = [
         Engagement with the Green Software Foundation is not a single pathway. The following forms have emerged from real collaborations.
       </p>
       <div class="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-        {engagementForms.map((item, index) => (
-          <div class="flex flex-col gap-3 rounded-xl border bg-accent-lightest-2 p-6">
-            <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-extrabold text-white">
-              {index + 1}
+        {engagementForms.map((item) => (
+          <div class="flex flex-col rounded-xl border bg-accent-lightest-2 p-6">
+            <h3 class="text-lg font-extrabold text-primary-dark">{item.title}</h3>
+            <p class="mt-3 flex-1 text-base leading-relaxed text-primary-dark">{item.body}</p>
+            <div class="mt-5">
+              <a
+                href={item.buttonHref}
+                class="inline-block rounded-lg bg-primary px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-primary-dark"
+              >
+                {item.buttonText}
+              </a>
             </div>
-            <p class="text-base leading-relaxed text-primary-dark">
-              <span class="font-extrabold">{item.title}</span>{item.body}
-            </p>
           </div>
         ))}
       </div>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -402,7 +402,7 @@ const membershipBenefits = [
   <!-- Academic member logos (directly below hero) -->
   {academicLogos.length > 0 ? (
     <LogoMarquee
-      heading="Institutions already working with the Green Software Foundation"
+      heading="Academic members of the GSF"
       logos={academicLogos}
       bgClass="bg-white"
       fadeBgClass="from-white"
@@ -413,7 +413,7 @@ const membershipBenefits = [
     <section class="bg-white py-10 md:py-12">
       <div class="container">
         <p class="mb-4 text-center text-sm font-medium text-gray-darker">
-          Institutions already working with the Green Software Foundation
+          Academic members of the GSF
         </p>
         <p class="text-center text-base font-semibold text-primary-dark">
           Chalmers University of Technology · Concordia University · University College London · University of Amsterdam · University of Bristol · University of Edinburgh · Manchester Metropolitan University · Texas State University

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -896,9 +896,9 @@ const membershipBenefits = [
   </section>
 
   <!-- Statement Banner -->
-  <section class="bg-primary py-16 md:py-20">
+  <section class="bg-primary py-10 md:py-12">
     <div class="container">
-      <p class="text-center text-3xl font-extrabold leading-tight text-white md:text-4xl lg:text-5xl">
+      <p class="text-center text-2xl font-extrabold leading-tight text-white md:text-3xl lg:text-4xl">
         Academic engagement within the GSF is{" "}
         <span class="text-accent">established</span>,{" "}
         not{" "}

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -505,33 +505,6 @@ const membershipBenefits = [
         </div>
       </div>
 
-      <div class="mx-auto mt-12 max-w-2xl">
-        <p class="text-center text-sm font-semibold uppercase tracking-wide text-primary">How engagement works</p>
-        <div class="mt-6 space-y-0">
-          {[
-            "Institutions submit an idea, proposal, or white paper using the form on this page.",
-            "The GSF Policy Working Group reviews all submissions and determines the appropriate form of engagement — which may include connection to a specific industry member, integration into an active Assembly or working group, or co-authorship on a GSF publication.",
-            "Where a strong match exists between a research submission and an active industry member challenge, GSF facilitates the introduction — subject to review and approval by the Policy Working Group.",
-            "Substantive collaborations may progress toward formal academic membership — available at no cost for qualifying institutions.",
-          ].map((step, i) => (
-            <div class="relative flex gap-5">
-              <div class="flex flex-col items-center">
-                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-bold text-white">
-                  {i + 1}
-                </div>
-                {i < 3 && <div class="w-0.5 grow bg-primary-lighter my-1" />}
-              </div>
-              <div class={`${i < 3 ? "pb-6" : "pb-0"} pt-1.5`}>
-                <p class="text-base leading-relaxed text-primary-dark">{step}</p>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <p class="mt-8 text-xs leading-relaxed text-gray-darker/70 italic">
-          There is no guaranteed outcome from submission. Every substantive proposal receives a considered review — decisions are made collectively by the Policy Working Group, not by a single point of contact. The process has genuine governance integrity.
-        </p>
-      </div>
     </div>
   </section>
 
@@ -919,120 +892,153 @@ const membershipBenefits = [
     </div>
   </section>
 
-  <!-- Section 7: Submission Form -->
+  <!-- Section 7: Submission Form + How Engagement Works (two-column) -->
   <section id="submission-form" class="bg-white py-16 md:py-20">
     <div class="container">
-      <div class="mx-auto max-w-2xl">
-        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Submit a Proposal</h2>
-        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
-          Submit your proposal, idea, or white paper using the form below. All submissions are reviewed by the GSF Policy Working Group, which determines next steps for engagement — including whether your research connects with an active challenge from a GSF member organisation.
-        </p>
+      <div class="grid gap-12 lg:grid-cols-[1fr_400px] lg:gap-16 xl:gap-20">
 
-        <div id="submission-form-wrap" class="mt-8">
-          <form id="academic-submission-form" class="space-y-5" novalidate>
-            <div>
-              <label for="full-name" class="mb-1 block text-sm font-semibold text-primary-dark">
-                Full name <span class="text-primary">*</span>
-              </label>
-              <input
-                type="text"
-                id="full-name"
-                name="full-name"
-                required
-                class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label for="job-title" class="mb-1 block text-sm font-semibold text-primary-dark">
-                Job title <span class="text-primary">*</span>
-              </label>
-              <input
-                type="text"
-                id="job-title"
-                name="job-title"
-                required
-                class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label for="institution" class="mb-1 block text-sm font-semibold text-primary-dark">
-                Institution name <span class="text-primary">*</span>
-              </label>
-              <input
-                type="text"
-                id="institution"
-                name="institution"
-                required
-                class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label for="email" class="mb-1 block text-sm font-semibold text-primary-dark">
-                Email address <span class="text-primary">*</span>
-              </label>
-              <input
-                type="email"
-                id="email"
-                name="email"
-                required
-                class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label for="research-area" class="mb-1 block text-sm font-semibold text-primary-dark">
-                Brief description of your research area <span class="text-primary">*</span>
-              </label>
-              <textarea
-                id="research-area"
-                name="research-area"
-                required
-                rows={5}
-                class="w-full resize-y rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              ></textarea>
-              <p class="mt-1 text-xs text-gray-darker">Max 300 words</p>
-            </div>
-            <div>
-              <label for="member-collab" class="mb-1 block text-sm font-semibold text-primary-dark">
-                Are you aware of any specific GSF member organisations you would like to explore
-                collaboration with?
-              </label>
-              <textarea
-                id="member-collab"
-                name="member-collab"
-                rows={3}
-                class="w-full resize-y rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              ></textarea>
-              <p class="mt-1 text-xs text-gray-darker">Optional · Max 100 words</p>
-            </div>
-            <div class="pt-2">
-              <button
-                type="submit"
-                class="rounded-lg bg-primary px-6 py-3 text-sm font-bold text-white transition-colors hover:bg-primary-dark"
-              >
-                Submit for Review
-              </button>
-            </div>
-            <p class="text-xs text-gray-darker">
-              By submitting this form you agree to GSF's{" "}
-              <a href="/privacy/" class="underline hover:text-primary-dark">privacy policy</a>.
-              Submissions are reviewed by the GSF Policy Working Group. We aim to acknowledge all
-              substantive submissions, though we do not publish a fixed response time.
-            </p>
-          </form>
+        <!-- Left: Submission Form -->
+        <div>
+          <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Submit a Proposal</h2>
+          <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
+            Submit your proposal, idea, or white paper using the form below. All submissions are reviewed by the GSF Policy Working Group, which determines next steps for engagement — including whether your research connects with an active challenge from a GSF member organisation.
+          </p>
 
-          <div
-            id="submission-confirmation"
-            class="hidden rounded-xl border border-primary/30 bg-white px-6 py-10 text-center shadow-sm"
-          >
-            <p class="text-lg font-semibold text-primary-dark">
-              Thank you — your submission has been received.
-            </p>
-            <p class="mt-3 text-sm text-gray-darker">
-              The GSF Policy Working Group will review your proposal. We aim to acknowledge all
-              substantive submissions.
-            </p>
+          <div id="submission-form-wrap" class="mt-8">
+            <form id="academic-submission-form" class="space-y-5" novalidate>
+              <div>
+                <label for="full-name" class="mb-1 block text-sm font-semibold text-primary-dark">
+                  Full name <span class="text-primary">*</span>
+                </label>
+                <input
+                  type="text"
+                  id="full-name"
+                  name="full-name"
+                  required
+                  class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+              </div>
+              <div>
+                <label for="job-title" class="mb-1 block text-sm font-semibold text-primary-dark">
+                  Job title <span class="text-primary">*</span>
+                </label>
+                <input
+                  type="text"
+                  id="job-title"
+                  name="job-title"
+                  required
+                  class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+              </div>
+              <div>
+                <label for="institution" class="mb-1 block text-sm font-semibold text-primary-dark">
+                  Institution name <span class="text-primary">*</span>
+                </label>
+                <input
+                  type="text"
+                  id="institution"
+                  name="institution"
+                  required
+                  class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+              </div>
+              <div>
+                <label for="email" class="mb-1 block text-sm font-semibold text-primary-dark">
+                  Email address <span class="text-primary">*</span>
+                </label>
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  required
+                  class="w-full rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+              </div>
+              <div>
+                <label for="research-area" class="mb-1 block text-sm font-semibold text-primary-dark">
+                  Brief description of your research area <span class="text-primary">*</span>
+                </label>
+                <textarea
+                  id="research-area"
+                  name="research-area"
+                  required
+                  rows={5}
+                  class="w-full resize-y rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                ></textarea>
+                <p class="mt-1 text-xs text-gray-darker">Max 300 words</p>
+              </div>
+              <div>
+                <label for="member-collab" class="mb-1 block text-sm font-semibold text-primary-dark">
+                  Are you aware of any specific GSF member organisations you would like to explore
+                  collaboration with?
+                </label>
+                <textarea
+                  id="member-collab"
+                  name="member-collab"
+                  rows={3}
+                  class="w-full resize-y rounded-lg border border-primary-lighter px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                ></textarea>
+                <p class="mt-1 text-xs text-gray-darker">Optional · Max 100 words</p>
+              </div>
+              <div class="pt-2">
+                <button
+                  type="submit"
+                  class="rounded-lg bg-primary px-6 py-3 text-sm font-bold text-white transition-colors hover:bg-primary-dark"
+                >
+                  Submit for Review
+                </button>
+              </div>
+              <p class="text-xs text-gray-darker">
+                By submitting this form you agree to GSF's{" "}
+                <a href="/privacy/" class="underline hover:text-primary-dark">privacy policy</a>.
+                Submissions are reviewed by the GSF Policy Working Group. We aim to acknowledge all
+                substantive submissions, though we do not publish a fixed response time.
+              </p>
+            </form>
+
+            <div
+              id="submission-confirmation"
+              class="hidden rounded-xl border border-primary/30 bg-white px-6 py-10 text-center shadow-sm"
+            >
+              <p class="text-lg font-semibold text-primary-dark">
+                Thank you — your submission has been received.
+              </p>
+              <p class="mt-3 text-sm text-gray-darker">
+                The GSF Policy Working Group will review your proposal. We aim to acknowledge all
+                substantive submissions.
+              </p>
+            </div>
           </div>
         </div>
+
+        <!-- Right: How Engagement Works -->
+        <div class="rounded-2xl bg-accent-lightest-2 p-6 md:p-8 lg:sticky lg:top-8 lg:self-start">
+          <p class="text-xs font-bold uppercase tracking-widest text-primary">How Engagement Works</p>
+          <div class="mt-5 space-y-0">
+            {[
+              "Institutions submit an idea, proposal, or white paper using the form on this page.",
+              "The GSF Policy Working Group reviews all submissions and determines the appropriate form of engagement — which may include connection to a specific industry member, integration into an active Assembly or working group, or co-authorship on a GSF publication.",
+              "Where a strong match exists between a research submission and an active industry member challenge, GSF facilitates the introduction — subject to review and approval by the Policy Working Group.",
+              "Substantive collaborations may progress toward formal academic membership — available at no cost for qualifying institutions.",
+            ].map((step, i) => (
+              <div class="relative flex gap-4">
+                <div class="flex flex-col items-center">
+                  <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-bold text-white">
+                    {i + 1}
+                  </div>
+                  {i < 3 && <div class="w-0.5 grow bg-primary/20 my-1" />}
+                </div>
+                <div class={`${i < 3 ? "pb-5" : "pb-0"} pt-1`}>
+                  <p class="text-sm leading-relaxed text-primary-dark">{step}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <p class="mt-6 text-xs leading-relaxed text-gray-darker/70 italic border-t border-accent-lighter pt-4">
+            There is no guaranteed outcome from submission. Every substantive proposal receives a considered review — decisions are made collectively by the Policy Working Group, not by a single point of contact. The process has genuine governance integrity.
+          </p>
+        </div>
+
       </div>
     </div>
   </section>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -684,77 +684,71 @@ const membershipBenefits = [
   <!-- Green AI Committee full-width section -->
   <section class="bg-primary py-16 md:py-20">
     <div class="container">
-      <div class="mx-auto max-w-5xl">
+      <!-- Centred header -->
+      <div class="text-center">
         <p class="mb-4 text-xs font-bold uppercase tracking-widest text-accent">GSF Committee</p>
         <h2 class="text-2xl font-extrabold text-white md:text-3xl lg:text-4xl">Green AI Committee</h2>
-        <p class="mt-6 max-w-3xl text-base leading-relaxed text-white/90 md:text-lg">
-          The Green AI Committee is GSF's dedicated policy and standards body responding to EU AI Act obligations — and was an active contributor to the SCI for AI ratification process. It coordinates GSF's collective technical response to AI environmental regulation across member organisations, translating industry deployment realities into policy positions that regulators can act on.
-        </p>
-        <p class="mt-4 max-w-3xl text-base leading-relaxed text-white/90 md:text-lg">
-          For academic researchers working at the intersection of AI, environmental assessment, and regulatory compliance, the Green AI Committee is the point of engagement — connecting academic expertise directly to the policy and standards processes where it carries weight.
-        </p>
-        <div class="mt-8 flex flex-wrap gap-4">
-          <a
-            href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
-            class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
-          >
-            EU AI Act analysis →
-          </a>
-          <a
-            href="#submission-form"
-            class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
-          >
-            Express your interest →
-          </a>
+      </div>
+
+      <!-- Two-column cards — one paragraph each, clearly labelled -->
+      <div class="mx-auto mt-10 grid max-w-5xl gap-5 md:grid-cols-2">
+        <div class="rounded-2xl bg-white/10 p-6 md:p-8">
+          <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">Policy &amp; Standards</p>
+          <p class="text-base leading-relaxed text-white/90">
+            The Green AI Committee is GSF's dedicated policy and standards body responding to EU AI Act obligations — and was an active contributor to the SCI for AI ratification process. It coordinates GSF's collective technical response to AI environmental regulation across member organisations, translating industry deployment realities into policy positions that regulators can act on.
+          </p>
+        </div>
+        <div class="rounded-2xl bg-white/10 p-6 md:p-8">
+          <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">For Academic Researchers</p>
+          <p class="text-base leading-relaxed text-white/90">
+            For academic researchers working at the intersection of AI, environmental assessment, and regulatory compliance, the Green AI Committee is the point of engagement — connecting academic expertise directly to the policy and standards processes where it carries weight.
+          </p>
+        </div>
+      </div>
+
+      <!-- CTAs centred -->
+      <div class="mt-8 flex flex-wrap justify-center gap-4">
+        <a
+          href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
+          class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
+        >
+          EU AI Act analysis →
+        </a>
+        <a
+          href="#submission-form"
+          class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
+        >
+          Express your interest →
+        </a>
+      </div>
+
+      <!-- Committee Members — unified grid -->
+      <div class="mx-auto mt-14 max-w-5xl">
+        <div class="mb-8 flex items-center gap-4">
+          <p class="shrink-0 text-xs font-bold uppercase tracking-widest text-white/50">Committee Members</p>
+          <div class="h-px flex-1 bg-white/20"></div>
         </div>
 
-        <!-- Committee Members -->
-        <div class="mt-14">
-          <div class="mb-8 flex items-center gap-4">
-            <p class="shrink-0 text-xs font-bold uppercase tracking-widest text-white/50">Committee Members</p>
-            <div class="h-px flex-1 bg-white/20"></div>
-          </div>
-
-          <!-- Co-chairs featured row -->
-          <div class="mb-6 grid gap-4 sm:grid-cols-2">
-            {committeeWithLogos.filter(m => m.role === "Co-Chair").map((member) => (
-              <div class="flex items-center gap-4 rounded-xl border border-white/20 bg-white p-5">
-                <div class="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-accent-lightest-2 p-2">
-                  {member.logo ? (
-                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
-                  ) : (
-                    <span class="text-xl font-extrabold text-primary">{member.initials}</span>
-                  )}
-                </div>
-                <div class="min-w-0">
-                  <div class="flex flex-wrap items-center gap-2">
-                    <p class="text-sm font-extrabold text-primary-dark">{member.name}</p>
-                    <span class="rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
-                  </div>
-                  <p class="mt-0.5 text-xs text-gray-darker">{member.org}</p>
-                </div>
+        <!-- All members in a single 4-column grid; co-chairs distinguished by badge -->
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {committeeWithLogos.map((member) => (
+            <div class="flex items-center gap-4 rounded-xl bg-white p-4">
+              <div class="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-accent-lightest-2 p-2">
+                {member.logo ? (
+                  <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
+                ) : (
+                  <span class="text-lg font-extrabold text-primary">{member.initials}</span>
+                )}
               </div>
-            ))}
-          </div>
-
-          <!-- Regular members grid -->
-          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {committeeWithLogos.filter(m => m.role !== "Co-Chair").map((member) => (
-              <div class="flex items-center gap-4 rounded-xl border border-white/20 bg-white p-4">
-                <div class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-accent-lightest-2 p-1.5">
-                  {member.logo ? (
-                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
-                  ) : (
-                    <span class="text-sm font-extrabold text-primary">{member.initials}</span>
-                  )}
-                </div>
-                <div class="min-w-0">
-                  <p class="truncate text-sm font-semibold leading-tight text-primary-dark">{member.name}</p>
-                  <p class="truncate text-xs text-gray-darker">{member.org}</p>
-                </div>
+              <div class="min-w-0">
+                <p class="text-sm font-extrabold leading-tight text-primary-dark">{member.name}</p>
+                <p class="mt-0.5 truncate text-xs text-gray-darker">{member.org}</p>
+                {member.role === "Co-Chair" && (
+                  <span class="mt-1.5 inline-block rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
+                )}
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -522,7 +522,21 @@ const membershipBenefits = [
       <p class="mx-auto mt-4 max-w-2xl text-center text-base text-primary-dark md:text-lg">
         GSF member organisations — spanning global banks, technology companies, infrastructure providers, and automotive manufacturers — regularly surface specific green software challenges that academic research is positioned to address.
       </p>
-      <div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    </div>
+  </section>
+
+  <!-- Full member logo marquee -->
+  <LogoMarquee
+    heading="GSF member organisations"
+    bgClass="bg-white"
+    fadeBgClass="from-white"
+    directoryHref="https://directory.greensoftware.foundation/members/"
+    directoryText="View all members"
+  />
+
+  <section class="bg-white pt-12 pb-16 md:pt-16 md:pb-20">
+    <div class="container">
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {workingOnCards.map((card) => (
           card.cta ? (
             <div class="flex flex-col rounded-lg border-2 border-dashed border-primary bg-primary/5 p-5">
@@ -559,15 +573,6 @@ const membershipBenefits = [
       </div>
     </div>
   </section>
-
-  <!-- Full member logo marquee -->
-  <LogoMarquee
-    heading="GSF member organisations"
-    bgClass="bg-white"
-    fadeBgClass="from-white"
-    directoryHref="https://directory.greensoftware.foundation/members/"
-    directoryText="View all members"
-  />
 
   <Testimonial
     quote="If your institution is active in any of these areas, use the submission form below. Our members' problem statements evolve as the field develops. This list is not exhaustive, and we welcome suggestions."

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -751,7 +751,7 @@ const membershipBenefits = [
               href="#submission-form"
               class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
             >
-              Express your interest →
+              GSF Academic Members can join the Green AI Committee →
             </a>
           </div>
         </div>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -1,0 +1,450 @@
+---
+import Layout from "@/layouts/showcase.astro";
+import { navItems } from "@/lib/nav-items";
+
+import Navbar from "@/components/navbar.astro";
+import Hero from "@/components/hero.astro";
+import LogoMarquee from "@/components/logo-marquee.astro";
+import TextBlock from "@/components/text-block.astro";
+import TextWithImage from "@/components/text-with-image.astro";
+import FeatureGrid from "@/components/feature-grid.astro";
+import ResourceCards from "@/components/resource-cards.astro";
+import CTABanner from "@/components/cta-banner.astro";
+import Footer from "@/components/footer.astro";
+---
+
+<Layout
+  title="Academic Membership — Green Software Foundation"
+  description="Free membership for universities and research institutions. Join 17 academic partners shaping international standards for sustainable software and hardware."
+>
+  <Navbar
+    logoSrc="/assets/gsf-logo-full.svg"
+    logoAlt="Green Software Foundation"
+    logoHref="/"
+    topBar="none"
+    showSearch
+    navItems={navItems}
+  />
+
+  <!-- Section 1: Hero -->
+  <Hero
+    heading="Academic membership in the"
+    headingAccent="Green Software Foundation"
+    body="The Green Software Foundation develops international standards for sustainable software and hardware. Academic membership gives your researchers direct access to the consensus process, the working groups, and the global network of organisations building them."
+    ctas={[
+      { text: "Enquire about academic membership", variant: "primary", href: "/membership/enquire/" },
+    ]}
+    imageSrc="/assets/hero-illustration.svg"
+    imageAlt="Academic membership illustration"
+    bgClass="bg-accent-lightest-2"
+  />
+
+  <!-- Section 2: Member logos — credibility -->
+  <LogoMarquee
+    heading="Our members include Microsoft, Google, Accenture, UBS, Goldman Sachs, Siemens, IBM, Cisco, NTT DATA, and over 60 other organisations — alongside 17 universities already participating"
+    greyscale={false}
+    bgClass="bg-white"
+    fadeBgClass="from-white"
+  />
+
+  <!-- Section 3: What the Foundation is working on -->
+  <TextBlock
+    heading="What the Foundation is *working on*"
+    body="Our active portfolio spans five domains. Each is governed by a dedicated Working Group or Committee, open to participation from all member organisations — including academic institutions."
+    compact
+  />
+
+  <FeatureGrid
+    columns={3}
+    features={[
+      {
+        icon: "/assets/standardized-icon.svg",
+        title: "Software Standards",
+        description: "Specifications that enable organisations to quantify and reduce the environmental impact of their software. Includes SCI (ISO/IEC 21031:2024), SCI for AI (ratified Dec 2025), SCI for Web, SEE, SWE, Carmen, SCI Guide, RTC, SOFT, SCI Self Certification, and SCI for Games.",
+      },
+      {
+        icon: "/assets/co2-icon.svg",
+        title: "Hardware Standards",
+        description: "Specifications addressing the full lifecycle of physical infrastructure — manufacturing, operation, and end-of-life. Active work: WDPC (Approved), Open19 (Published). In development: SCI for Circularity, where expertise in materials science and lifecycle assessment is particularly relevant.",
+      },
+      {
+        icon: "/assets/realtime-icon.svg",
+        title: "AI & Energy Efficiency",
+        description: "AI energy consumption is projected to more than quadruple by 2030. The Green AI Committee coordinates standards and educational work: SCI for AI across six lifecycle stages, the Green AI Practitioner Course (in proposal), and regulatory analysis of the EU AI Act and AI Environmental Impacts Act.",
+      },
+      {
+        icon: "/assets/shape-icon-3.svg",
+        title: "Policy & Regulation",
+        description: "The Policy Working Group tracks emerging legislation, produces position papers, and ensures GSF standards inform regulatory frameworks. Output includes the Policy Radar, CSRD Scope 3 compliance guidance, EU AI Act analysis, and the State of Green Software Report.",
+      },
+      {
+        icon: "/assets/renewable-icon.svg",
+        title: "Education, Tooling & Adoption",
+        description: "The Developer Relations Committee maintains open-source tools and educational resources. Includes the Green Software Practitioner Course (130,000+ completions), Green Software Patterns, Awesome Green Software, Carbon Aware SDK (deployed in production banking at UBS), and the Impact Framework.",
+      },
+    ]}
+  />
+
+  <!-- Section 4: What membership enables -->
+  <TextBlock
+    heading="*What* academic membership enables"
+    body="Membership provides your researchers with the same access and governance rights as all other member organisations."
+    compact
+  />
+
+  <FeatureGrid
+    columns={2}
+    features={[
+      {
+        icon: "/assets/dive-icon-1.svg",
+        title: "Participation in all Working Groups and Committees",
+        description: "Software Standards, Hardware Standards, Policy, Green AI, and Developer Relations — full participation rights from day one.",
+      },
+      {
+        icon: "/assets/dive-icon-2.svg",
+        title: "Assembly participation",
+        description: "The intensive, AI-facilitated consensus workshops where new specifications are designed. The SCI for Web specification went from a blank page to a consensus design document in ten weeks with 14 experts from 15 organisations.",
+      },
+      {
+        icon: "/assets/dive-icon-3.svg",
+        title: "Propose new specifications",
+        description: "The right to propose new specifications through the formal Assembly process — on equal footing with any other member organisation.",
+      },
+      {
+        icon: "/assets/dive-icon-4.svg",
+        title: "Chair working groups and projects",
+        description: "The right to chair working groups, sub-working groups, and projects — and to lead initiatives that shape the direction of published specifications.",
+      },
+      {
+        icon: "/assets/shape-icon-1.svg",
+        title: "Co-authorship credit",
+        description: "Co-authorship credit on published and ISO-certified specifications — including any specifications your researchers help develop.",
+      },
+      {
+        icon: "/assets/shape-icon-2.svg",
+        title: "Formal consensus rights",
+        description: "The ability to endorse, consent to, or formally object to any proposal. A single objection from any member triggers a structured resolution process. This mechanism has materially shaped the direction of published GSF specifications.",
+      },
+      {
+        icon: "/assets/shape-icon-3.svg",
+        title: "Curriculum licensing",
+        description: "Licensing for the Green Software Practitioner course and the forthcoming Green AI Practitioner course — available for integration into your institution's curriculum.",
+      },
+      {
+        icon: "/assets/shape-icon-4.svg",
+        title: "No fees",
+        description: "Both GSF and Linux Foundation membership are provided at no cost to academic institutions. There is no minimum engagement requirement.",
+      },
+    ]}
+  />
+
+  <!-- Section 5: Discipline mapping table -->
+  <section class="bg-accent-lightest-2 py-16 md:py-20">
+    <div class="container">
+      <div class="mx-auto max-w-5xl">
+        <div class="text-center mb-10">
+          <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">
+            Where academic expertise <span class="font-bold text-primary">aligns with the Foundation's work</span>
+          </h2>
+          <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
+            The table below maps research disciplines to active GSF projects — to help identify where your institution's existing research may be most relevant.
+          </p>
+        </div>
+
+        <!-- Desktop table -->
+        <div class="hidden md:block overflow-hidden rounded-xl border bg-white shadow-sm">
+          <table class="w-full text-left">
+            <thead>
+              <tr class="border-b bg-primary-darker text-white">
+                <th class="px-6 py-4 text-sm font-bold w-1/3">Discipline</th>
+                <th class="px-6 py-4 text-sm font-bold">Relevant GSF work</th>
+              </tr>
+            </thead>
+            <tbody class="text-sm text-primary-dark">
+              {[
+                {
+                  discipline: "Computer Science & Software Engineering",
+                  work: "SCI, SCI for AI, SCI for Web, SEE, Carmen, Carbon Aware SDK, Impact Framework, Green Software Patterns",
+                },
+                {
+                  discipline: "AI & Machine Learning",
+                  work: "SCI for AI, Green AI Committee, Green AI Practitioner Course, AI-accelerated consensus methodology",
+                },
+                {
+                  discipline: "Environmental Science & Sustainability",
+                  work: "SWE, lifecycle carbon accounting, SCI validation, State of Green Software Report",
+                },
+                {
+                  discipline: "Electrical & Hardware Engineering",
+                  work: "WDPC, Open19, embodied carbon in semiconductors, data centre efficiency, SCI for Circularity",
+                },
+                {
+                  discipline: "Materials Science, Industrial Ecology & Lifecycle Assessment",
+                  work: "SCI for Circularity (SCIC), lifecycle extension, material recovery, embodied carbon methodology",
+                },
+                {
+                  discipline: "Policy, Law & Governance",
+                  work: "Policy Radar, CSRD Scope 3 analysis, EU AI Act, AI Environmental Impacts Act",
+                },
+                {
+                  discipline: "Management & Organisational Science",
+                  work: "SOFT framework validation, sustainability adoption, consensus-building methodology",
+                },
+                {
+                  discipline: "Gaming & Interactive Media",
+                  work: "SCI for Games, carbon-per-hour measurement, cross-platform energy benchmarking",
+                },
+                {
+                  discipline: "HPC & Research Computing",
+                  work: "SCI applied to high-performance computing, Carbon Aware SDK for workload scheduling",
+                },
+              ].map((row, i) => (
+                <tr class={`border-b last:border-b-0 ${i % 2 === 1 ? "bg-accent-lightest-1/50" : ""}`}>
+                  <td class="px-6 py-4 font-semibold align-top">{row.discipline}</td>
+                  <td class="px-6 py-4 text-gray-darker">{row.work}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile cards -->
+        <div class="space-y-3 md:hidden">
+          {[
+            { discipline: "Computer Science & Software Engineering", work: "SCI, SCI for AI, SCI for Web, SEE, Carmen, Carbon Aware SDK, Impact Framework, Green Software Patterns" },
+            { discipline: "AI & Machine Learning", work: "SCI for AI, Green AI Committee, Green AI Practitioner Course, AI-accelerated consensus methodology" },
+            { discipline: "Environmental Science & Sustainability", work: "SWE, lifecycle carbon accounting, SCI validation, State of Green Software Report" },
+            { discipline: "Electrical & Hardware Engineering", work: "WDPC, Open19, embodied carbon in semiconductors, data centre efficiency, SCI for Circularity" },
+            { discipline: "Materials Science, Industrial Ecology & Lifecycle Assessment", work: "SCI for Circularity (SCIC), lifecycle extension, material recovery, embodied carbon methodology" },
+            { discipline: "Policy, Law & Governance", work: "Policy Radar, CSRD Scope 3 analysis, EU AI Act, AI Environmental Impacts Act" },
+            { discipline: "Management & Organisational Science", work: "SOFT framework validation, sustainability adoption, consensus-building methodology" },
+            { discipline: "Gaming & Interactive Media", work: "SCI for Games, carbon-per-hour measurement, cross-platform energy benchmarking" },
+            { discipline: "HPC & Research Computing", work: "SCI applied to high-performance computing, Carbon Aware SDK for workload scheduling" },
+          ].map((row) => (
+            <div class="rounded-lg border bg-white px-5 py-4 shadow-sm">
+              <p class="font-semibold text-primary-dark text-sm">{row.discipline}</p>
+              <p class="mt-1 text-sm text-gray-darker">{row.work}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 6: Universities currently participating -->
+  <section class="bg-white py-16 md:py-20">
+    <div class="container">
+      <div class="mx-auto max-w-4xl">
+        <div class="text-center mb-10">
+          <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">
+            <span class="font-bold text-primary">17 universities</span> currently participating
+          </h2>
+          <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
+            Active GSF members contributing to standards development alongside global technology and financial services organisations.
+          </p>
+        </div>
+
+        <!-- Desktop table -->
+        <div class="hidden md:block overflow-hidden rounded-xl border shadow-sm">
+          <table class="w-full text-left">
+            <thead>
+              <tr class="border-b bg-primary-darker text-white">
+                <th class="px-6 py-4 text-sm font-bold">Institution</th>
+                <th class="px-6 py-4 text-sm font-bold">Location</th>
+              </tr>
+            </thead>
+            <tbody class="text-sm text-primary-dark">
+              {[
+                { name: "UCL", location: "London, UK" },
+                { name: "University of Edinburgh", location: "Edinburgh, UK" },
+                { name: "University of Bristol", location: "Bristol, UK" },
+                { name: "University of Amsterdam", location: "Amsterdam, Netherlands" },
+                { name: "Chalmers University of Technology", location: "Gothenburg, Sweden" },
+                { name: "Concordia University", location: "Montreal, Canada" },
+                { name: "Universidad Politécnica de Madrid", location: "Madrid, Spain" },
+                { name: "Università degli Studi dell'Aquila", location: "L'Aquila, Italy" },
+                { name: "University of Limerick", location: "Limerick, Ireland" },
+                { name: "Linnaeus University", location: "Växjö, Sweden" },
+                { name: "Manchester Metropolitan University", location: "Manchester, UK" },
+                { name: "University of Huddersfield", location: "Huddersfield, UK" },
+                { name: "University of Salento", location: "Lecce, Italy" },
+                { name: "Texas State University", location: "San Marcos, USA" },
+                { name: "Mondragon University", location: "Mondragón, Spain" },
+                { name: "IIIT Hyderabad", location: "Hyderabad, India" },
+                { name: "IIM Mumbai", location: "Mumbai, India" },
+              ].map((uni, i) => (
+                <tr class={`border-b last:border-b-0 ${i % 2 === 1 ? "bg-accent-lightest-1/50" : ""}`}>
+                  <td class="px-6 py-4 font-semibold">{uni.name}</td>
+                  <td class="px-6 py-4 text-gray-darker">{uni.location}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p class="px-6 py-3 text-xs text-gray-darker bg-accent-lightest-1/30 border-t">
+            Verified against the GSF Member Directory, March 2026.
+          </p>
+        </div>
+
+        <!-- Mobile cards -->
+        <div class="space-y-2 md:hidden">
+          {[
+            { name: "UCL", location: "London, UK" },
+            { name: "University of Edinburgh", location: "Edinburgh, UK" },
+            { name: "University of Bristol", location: "Bristol, UK" },
+            { name: "University of Amsterdam", location: "Amsterdam, Netherlands" },
+            { name: "Chalmers University of Technology", location: "Gothenburg, Sweden" },
+            { name: "Concordia University", location: "Montreal, Canada" },
+            { name: "Universidad Politécnica de Madrid", location: "Madrid, Spain" },
+            { name: "Università degli Studi dell'Aquila", location: "L'Aquila, Italy" },
+            { name: "University of Limerick", location: "Limerick, Ireland" },
+            { name: "Linnaeus University", location: "Växjö, Sweden" },
+            { name: "Manchester Metropolitan University", location: "Manchester, UK" },
+            { name: "University of Huddersfield", location: "Huddersfield, UK" },
+            { name: "University of Salento", location: "Lecce, Italy" },
+            { name: "Texas State University", location: "San Marcos, USA" },
+            { name: "Mondragon University", location: "Mondragón, Spain" },
+            { name: "IIIT Hyderabad", location: "Hyderabad, India" },
+            { name: "IIM Mumbai", location: "Mumbai, India" },
+          ].map((uni) => (
+            <div class="flex items-center justify-between rounded-lg border bg-white px-5 py-3 shadow-sm">
+              <span class="font-semibold text-primary-dark text-sm">{uni.name}</span>
+              <span class="text-sm text-gray-darker">{uni.location}</span>
+            </div>
+          ))}
+          <p class="pt-2 text-xs text-gray-darker text-center">Verified against the GSF Member Directory, March 2026.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 7: Relevance to institutional sustainability objectives -->
+  <TextWithImage
+    heading="Relevance to your institution's"
+    headingAccent="sustainability objectives"
+    body="Universities operate computationally intensive infrastructure — HPC clusters, research data centres, AI training facilities, campus IT systems — and face the same measurement and reporting requirements as commercial organisations. The SCI specification provides a standardised, ISO-certified method to measure the carbon intensity of institutional computation. The SEE and SWE specifications extend this to energy and water. The WDPC and Open19 hardware standards address the physical infrastructure layer. The forthcoming SCI for Circularity specification will be directly applicable to university hardware procurement, refresh cycles, and e-waste management. The SOFT framework supports systematic implementation across departments and faculties. Institutions applying GSF standards to their own infrastructure also generate implementation case studies that strengthen the specifications and demonstrate their applicability beyond commercial settings."
+    imageSrc="/assets/dive-illustration.svg"
+    imageAlt="Institutional sustainability illustration"
+  />
+
+  <!-- Section 8: Complementary academic programmes -->
+  <ResourceCards
+    heading="Complementary *academic programmes*"
+    body="GSF's standards portfolio intersects with several established academic initiatives."
+    columns={2}
+    cards={[
+      {
+        icon: "/assets/shape-icon-1.svg",
+        title: "Erasmus Mundus SE4GD",
+        description: "The joint Master's programme in Software Engineering for Green Deal, across LUT University (Finland), Università degli Studi dell'Aquila (Italy), and Vrije Universiteit Amsterdam (Netherlands). Two of the three consortium universities are GSF members. The programme's curriculum aligns with GSF's standards portfolio.",
+        ctaText: "Learn about SE4GD →",
+        ctaHref: "https://se4gd.lutfoundation.fi",
+      },
+      {
+        icon: "/assets/shape-icon-2.svg",
+        title: "GREENER Principles",
+        description: "The framework for environmentally sustainable computational science (Lannelongue et al., Nature Computational Science, 2023). GSF standards provide the measurement methodology these principles require.",
+        ctaText: "Read the paper →",
+        ctaHref: "https://doi.org/10.1038/s43588-023-00461-y",
+      },
+      {
+        icon: "/assets/shape-icon-3.svg",
+        title: "ARCHER2 Sustainable HPC Training",
+        description: "The UK national supercomputing service references GSF principles and the SCI methodology in its sustainable computing curriculum.",
+        ctaText: "Visit ARCHER2 →",
+        ctaHref: "https://www.archer2.ac.uk",
+      },
+      {
+        icon: "/assets/shape-icon-4.svg",
+        title: "Texas State University SCI Validation",
+        description: "Published research from a GSF academic member confirming SCI as an effective metric for evaluating the carbon impact of foundation models — independent validation from within the academic community.",
+        ctaText: "View the research →",
+        ctaHref: "/policy/research/",
+      },
+    ]}
+  />
+
+  <!-- Section 9: How to enquire -->
+  <FeatureGrid
+    heading="How to *enquire*"
+    body="If your institution has research aligned with the Foundation's work and you would like to explore membership:"
+    variant="bordered"
+    columns={2}
+    features={[
+      {
+        icon: "/assets/dive-icon-1.svg",
+        title: "1. Get in touch",
+        description: "Contact Jamie Cowan, Head of Sales & Partnerships — jamie.cowan@greensoftware.foundation. Academic membership is free and the process is straightforward.",
+      },
+      {
+        icon: "/assets/dive-icon-2.svg",
+        title: "2. Brief alignment conversation",
+        description: "A short conversation to identify which working groups, committees, or projects represent the strongest fit for your researchers.",
+      },
+      {
+        icon: "/assets/dive-icon-3.svg",
+        title: "3. Formal enrolment",
+        description: "Completed through the Linux Foundation portal. The process carries no fees for academic institutions — neither GSF nor Linux Foundation membership.",
+      },
+      {
+        icon: "/assets/dive-icon-4.svg",
+        title: "4. Onboarding",
+        description: "Introduction to relevant project chairs, access to repositories and communication channels, and connection with existing academic members working in adjacent areas.",
+      },
+    ]}
+  />
+
+  <!-- Section 10: FAQ -->
+  <section class="bg-accent-lightest-2 py-16 md:py-20">
+    <div class="container">
+      <div class="mx-auto max-w-3xl">
+        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl text-center mb-10">
+          Frequently asked <span class="font-bold text-primary">questions</span>
+        </h2>
+        <div class="space-y-3">
+          {[
+            {
+              q: "Is membership genuinely free for academic institutions?",
+              a: "Yes. Both GSF and Linux Foundation membership are provided at no cost to academic institutions, non-profits, and government organisations.",
+            },
+            {
+              q: "Can postgraduate students and early-career researchers participate?",
+              a: "Yes. Any enrolled student or employee at a member institution may register and participate in working groups and projects.",
+            },
+            {
+              q: "Can we integrate GSF materials into our teaching?",
+              a: "Yes. The Green Software Practitioner course and related materials are available for curriculum integration. Licensing is discussed during onboarding.",
+            },
+            {
+              q: "Can we propose new specifications?",
+              a: "Yes. Academic members have the same rights as any other member to propose and lead new initiatives through the Assembly process.",
+            },
+            {
+              q: "How does GSF relate to the SE4GD programme?",
+              a: "Two of the three SE4GD consortium universities are GSF members. The programme's curriculum and GSF's standards portfolio are closely aligned. We welcome further collaboration with SE4GD-affiliated institutions.",
+            },
+          ].map((item) => (
+            <details class="group rounded-xl border bg-white shadow-sm open:shadow-md transition-shadow">
+              <summary class="flex cursor-pointer items-center justify-between gap-4 px-6 py-5 font-semibold text-primary-dark list-none">
+                <span>{item.q}</span>
+                <span class="shrink-0 text-primary transition-transform group-open:rotate-45 text-xl leading-none">+</span>
+              </summary>
+              <div class="px-6 pb-5 text-sm leading-relaxed text-gray-darker border-t pt-4">
+                {item.a}
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 11: Final CTA -->
+  <CTABanner
+    heading="Academic membership is *provided at no cost*"
+    body="Both GSF and Linux Foundation membership are free for academic institutions. If your institution has research aligned with our work, membership may warrant a conversation."
+    ctaText="Enquire about academic membership"
+    ctaHref="/membership/enquire/"
+  />
+
+  <Footer />
+</Layout>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -192,6 +192,15 @@ const hardwareStandards = [
     link: "/standards/open19/",
     linkText: "About Open19",
   },
+  {
+    title: "Software Carbon Intensity for Circularity (SCI-C)",
+    status: "In Progress",
+    statusColor: "bg-primary/10 text-primary",
+    description:
+      "SCI-C is the first standard to create a direct, measurable link between software release decisions and hardware retirement at scale. For any organisation with a large device fleet, a data centre footprint, or EU regulatory exposure on circularity — under CSRD, the Circular Economy Action Plan, and right-to-repair legislation — this is a standard they will want to have shaped from the inside rather than inherited from outside.",
+    link: "#submission-form",
+    linkText: "We welcome your submission or ideas",
+  },
 ];
 
 const crossCuttingAreas = [

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -742,16 +742,16 @@ const membershipBenefits = [
           </div>
           <div class="flex flex-wrap gap-3 pt-2">
             <a
-              href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
+              href="#submission-form"
               class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
             >
-              EU AI Act analysis →
+              GSF Academic Members can join the Green AI Committee →
             </a>
             <a
-              href="#submission-form"
+              href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
               class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
             >
-              GSF Academic Members can join the Green AI Committee →
+              EU AI Act analysis →
             </a>
           </div>
         </div>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -18,11 +18,7 @@ const academicLogos = (membersData as any[])
     website: m.companyWebsite || "greensoftware.foundation",
   }));
 
-const heroBody = [
-  "The Green Software Foundation is where a computer science department's measurement methodology research connects directly to the ESG reporting reality of a Fortune 500 company implementing it next quarter. No other organisation holds both sides of that relationship simultaneously.",
-  "GSF convenes the industry members who need answers and the research institutions who develop them — and provides the governance infrastructure to turn that collaboration into ratified, ISO-certified standards.",
-  "If your institution is working on software sustainability, AI energy footprint, or digital environmental methodology — there are GSF members actively looking for what you are already building.",
-].join("<br><br>");
+const heroBody = "If your institution is working on software sustainability, AI energy footprint, or digital environmental methodology — there are GSF members actively looking for what you are already building.";
 
 const workingOnCards = [
   {
@@ -189,6 +185,42 @@ const membershipBenefits = [
     imageAlt="Academic & Research Engagement illustration"
     bgClass="bg-accent-lightest-2"
   />
+
+  <!-- Bridge section: GSF's unique position -->
+  <section class="bg-primary py-14 md:py-20">
+    <div class="container">
+      <div class="mx-auto max-w-4xl">
+        <!-- Two-column bridge visual -->
+        <div class="flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-5 mb-10 md:mb-12">
+          <div class="rounded-xl border border-white/20 bg-white/10 px-6 py-4 text-center sm:flex-1 sm:max-w-xs">
+            <p class="text-xs font-bold uppercase tracking-widest text-white/50">Research Institutions</p>
+            <p class="mt-1.5 text-base font-extrabold text-white">Methodology &amp; Rigour</p>
+          </div>
+          <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-white/30 text-white font-bold text-lg">
+            +
+          </div>
+          <div class="rounded-xl border border-white/20 bg-white/10 px-6 py-4 text-center sm:flex-1 sm:max-w-xs">
+            <p class="text-xs font-bold uppercase tracking-widest text-white/50">Industry Members</p>
+            <p class="mt-1.5 text-base font-extrabold text-white">Real-World Deployment</p>
+          </div>
+        </div>
+
+        <!-- Statement text -->
+        <div class="text-center">
+          <p class="text-xl font-extrabold leading-snug text-white md:text-2xl lg:text-3xl">
+            GSF is where a computer science department's measurement methodology research connects directly to the ESG reporting reality of a Fortune 500 company implementing it next quarter.
+          </p>
+          <p class="mt-4 text-base font-semibold text-white/70 md:text-lg">
+            No other organisation holds both sides of that relationship simultaneously.
+          </p>
+          <div class="mx-auto mt-8 h-px w-16 bg-white/20"></div>
+          <p class="mx-auto mt-8 max-w-2xl text-base leading-relaxed text-white/80 md:text-lg">
+            GSF convenes the industry members who need answers and the research institutions who develop them — and provides the governance infrastructure to turn that collaboration into ratified, ISO-certified standards.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
 
   <!-- Section 2: The Convening Model -->
   <section class="bg-white py-16 md:py-24">

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -490,7 +490,7 @@ const membershipBenefits = [
   <section class="bg-accent-lightest-2 py-16 md:py-24">
     <div class="container">
       <p class="mb-3 text-center text-xs font-bold uppercase tracking-widest text-primary">How It Works</p>
-      <h2 class="text-center text-2xl font-extrabold md:text-3xl lg:text-4xl">The Convening <span class="text-primary">Model</span></h2>
+      <h2 class="text-center text-2xl font-extrabold md:text-3xl lg:text-4xl">Where Academia <span class="text-primary">Connects</span> with Enterprise</h2>
 
       <div class="mx-auto mt-8 grid max-w-5xl gap-6 md:grid-cols-2 md:gap-10">
         <div class="rounded-2xl border border-accent-lighter bg-white p-6 md:p-8">

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -207,18 +207,21 @@ const membershipBenefits = [
   <!-- Section 4: Forms of Engagement -->
   <section class="bg-white py-16 md:py-20">
     <div class="container">
-      <div class="mx-auto max-w-3xl">
-        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Forms of Engagement</h2>
-        <p class="mt-4 text-base leading-relaxed text-primary-dark md:text-lg">
-          Engagement with the Green Software Foundation is not a single pathway. The following forms have emerged from real collaborations.
-        </p>
-        <ul class="mt-6 space-y-4">
-          {engagementForms.map((item) => (
-            <li class="text-base leading-relaxed text-primary-dark">
-              <span class="font-bold">{item.title}</span>{item.body}
-            </li>
-          ))}
-        </ul>
+      <h2 class="text-center text-2xl font-semibold md:text-3xl lg:text-4xl">Forms of Engagement</h2>
+      <p class="mx-auto mt-4 max-w-2xl text-center text-base leading-relaxed text-primary-dark md:text-lg">
+        Engagement with the Green Software Foundation is not a single pathway. The following forms have emerged from real collaborations.
+      </p>
+      <div class="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {engagementForms.map((item, index) => (
+          <div class="flex flex-col gap-3 rounded-xl border bg-accent-lightest-2 p-6">
+            <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-extrabold text-white">
+              {index + 1}
+            </div>
+            <p class="text-base leading-relaxed text-primary-dark">
+              <span class="font-extrabold">{item.title}</span>{item.body}
+            </p>
+          </div>
+        ))}
       </div>
     </div>
   </section>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -109,28 +109,197 @@ const engagementForms = [
   },
 ];
 
-const standardsItems = [
+const softwareStandards = [
   {
-    title: "SCI Standard — ISO/IEC 21031:2024",
+    title: "Software Carbon Intensity (SCI)",
+    status: "Published · ISO/IEC 21031:2024",
+    statusColor: "bg-primary/10 text-primary",
     description:
-      "The only ISO-certified metric for software carbon. Active research need: independent methodology validation; domain extension to emerging system types; implementation benchmarking across sectors.",
-    link: "https://sci.greensoftware.foundation/",
-    linkText: "View the SCI standard →",
+      "Measures carbon intensity of software as a rate per unit of work. The only ISO-certified metric for software carbon — the foundation for all downstream SCI extensions and the primary metric referenced in CSRD Scope 3 reporting.",
+    link: "/standards/sci/",
+    linkText: "About the SCI Standard",
   },
   {
-    title: "SCI for AI — ratified December 2025",
+    title: "SCI for Artificial Intelligence",
+    status: "Ratified · Dec 2025",
+    statusColor: "bg-primary/10 text-primary",
     description:
-      "The first consensus-based standard for measuring AI carbon footprint across six lifecycle stages. Active research need: training vs. inference carbon apportionment; embodied carbon in AI hardware; long-running workload optimisation. A UCL team's carbon-aware scheduler work — presented to the GSF Steering Committee in April 2026 — demonstrates the level of applied academic engagement the Foundation actively supports.",
+      "Extends SCI to cover AI systems across the full lifecycle — training, fine-tuning, inference, storage, transmission, and end-of-life. Directly addresses the gap in existing corporate AI emissions reporting. A UCL carbon-aware scheduler project, presented to the GSF Steering Committee in April 2026, demonstrated 44–56% carbon savings.",
+    link: "/standards/sci-ai/",
+    linkText: "About SCI for AI",
   },
   {
-    title: "SCI for Web — in active development",
+    title: "SCI for Web",
+    status: "Draft",
+    statusColor: "bg-yellow-100 text-yellow-800",
     description:
-      "Extending SCI methodology to web-based software. Active research need: design foundations for the specification; measurement methodology for client-side and CDN carbon. Academic input is directly relevant at this early stage.",
+      "Extends SCI to web applications and digital services. Developed via AI-accelerated consensus process — 14 experts, 15 organisations, full agreement in 10 weeks. An early-stage specification where academic input into design foundations and client-side measurement methodology is directly relevant.",
+    link: "/standards/sci-web/",
+    linkText: "About SCI for Web",
   },
   {
-    title: "SOFT Framework — ratified November 2025",
+    title: "Sustainable Organisational Framework for Technology (SOFT)",
+    status: "Ratified · Nov 2025",
+    statusColor: "bg-primary/10 text-primary",
     description:
-      "The first ratified standard for embedding green software practices across an entire organisation. Active research need: implementation case studies; compliance pathway analysis under CSRD; sector-specific adaptation frameworks.",
+      "The first ratified standard for embedding green software practice across an entire organisation — not just individual projects. Addresses the endemic problem of green pilots that never scale. Active research need: implementation case studies; CSRD compliance pathway analysis; sector-specific adaptation frameworks.",
+    link: "/standards/soft/",
+    linkText: "About the SOFT Framework",
+  },
+  {
+    title: "Real Time Energy and Carbon Standard for Cloud (RTC)",
+    status: "Published",
+    statusColor: "bg-primary/10 text-primary",
+    description:
+      "Establishes a benchmark for real-time carbon and energy reporting by cloud providers. Underpins demand-side carbon-aware computing and directly feeds into the Carbon Aware SDK. Active research need: granular grid carbon intensity data integration; provider compliance benchmarking.",
+    link: "/standards/rtc/",
+    linkText: "About the RTC Standard",
+  },
+  {
+    title: "Software Energy Efficiency (SEE)",
+    status: "Pre-Draft",
+    statusColor: "bg-orange-100 text-orange-700",
+    description:
+      "Methodology for calculating the energy consumption rate of a software system. Earlier in the specification lifecycle — an active research area where foundational academic input can directly shape the standard's direction. Not yet ratified.",
+    link: "/standards/see/",
+    linkText: "About SEE",
+  },
+  {
+    title: "Software Water Efficiency (SWE)",
+    status: "Pre-Proposal",
+    statusColor: "bg-gray-100 text-gray-600",
+    description:
+      "Methodology for calculating the water consumption rate of a software system. At the earliest lifecycle stage — signals GSF's forward research agenda into water as a resource constraint alongside carbon and energy. Academic research proposals in this area are particularly welcome.",
+  },
+];
+
+const hardwareStandards = [
+  {
+    title: "Workload Dynamic Power and Cooling (WDPC)",
+    status: "Approved",
+    statusColor: "bg-primary/10 text-primary",
+    description:
+      "Standardises data coordination between computational workloads and energy and cooling infrastructure. Critical for data centre operators optimising at the hardware–software boundary, and underpins defensible measurement baselines for EU mandatory environmental reporting.",
+    link: "/standards/wdpc/",
+    linkText: "About the WDPC Standard",
+  },
+  {
+    title: "Open19",
+    status: "Published",
+    statusColor: "bg-primary/10 text-primary",
+    description:
+      "Open hardware specification standardising server, storage, and networking form factors within the 19-inch rack footprint. Features 48V DC native power architecture, modular design, and pluggable liquid cooling — enabling multi-vendor flexibility and sustainable hardware innovation.",
+    link: "/standards/open19/",
+    linkText: "About Open19",
+  },
+];
+
+const crossCuttingAreas = [
+  {
+    title: "SCI for Games",
+    description:
+      "Joint GSF and Sustainable Games Alliance initiative launched March 2026. Applies SCI measurement methodology to the gaming industry — a high-energy sector with limited existing sustainability metrics.",
+  },
+  {
+    title: "SCI for OpenTelemetry",
+    description:
+      "Assembly-in-formation linking SCI measurement to OTel observability tooling, with Goldman Sachs as assembly champion. Research need: integrating carbon intensity signals into existing engineering observability stacks.",
+  },
+  {
+    title: "SCI for Automotive (ECUs / LCA)",
+    description:
+      "Exploratory thread with Volvo applying SCI methodology to embedded software in vehicles. Addresses lifecycle carbon assessment for automotive ECU software — a domain where academic expertise in embedded systems and LCA methodology is directly applicable.",
+  },
+  {
+    title: "SCI Disclosure Certification",
+    description:
+      "Voluntary structured self-reporting programme under development. Bridges SCI into ESG and CSRD disclosure workflows — providing a certification pathway for organisations that want to demonstrate SCI compliance in regulatory reporting.",
+  },
+  {
+    title: "Green AI Committee",
+    description:
+      "Policy and standards body responding to EU AI Act obligations and active contributor to the SCI for AI ratification process. Coordinates GSF's technical response to AI environmental regulation across member organisations.",
+  },
+  {
+    title: "Hardware–Software Interoperability for Data Centre Sustainability",
+    description:
+      "Assembly seeded by Zutacore, sitting at the intersection of WDPC and operational data centre practice. Addresses the gap between hardware-level efficiency metrics and software-level workload decisions.",
+  },
+];
+
+const policyEngagements = [
+  {
+    title: "GHG Protocol Scope 2 Consultation",
+    description:
+      "Formal response submitted. GSF argued for time- and location-sensitive emissions data, pushing back against annual averages and broad geographic boundaries that strip out the granularity software engineers need to act.",
+    link: "/articles/why-the-gsf-is-participating-in-the-ghg-protocol-scope-2-consultation/",
+    linkText: "Read the response",
+  },
+  {
+    title: "AI Environmental Impacts Act",
+    description:
+      "GSF's first formal policy endorsement. Called for mandated environmental impact studies on AI, an AI Environmental Impacts Consortium, and a voluntary reporting framework for AI developers.",
+    link: "/articles/the-gsf-endorses-the-ai-environmental-impacts-act/",
+    linkText: "Read the endorsement",
+  },
+  {
+    title: "EU AI Act",
+    description:
+      "Analysis via the Green AI Committee on what the first binding global AI regulation means for sustainable software development and emissions disclosure. Directly relevant to researchers working on AI environmental assessment frameworks.",
+    link: "/articles/the-eu-ai-act-insights-from-the-green-ai-committee/",
+    linkText: "Read the analysis",
+  },
+  {
+    title: "NY Corporate Climate Accountability Act",
+    description:
+      "Coordinated technical responses to proposed New York state legislation on corporate climate accountability. GSF contributed standards expertise to the policy development process.",
+  },
+  {
+    title: "European Green Digital Coalition (EGDC)",
+    description:
+      "Engaging to align GSF standards with EU digital sustainability policy objectives. Provides a route for academic research that informs GSF standards to reach EU-level policy formation.",
+  },
+  {
+    title: "UK Government Digital Sustainability Alliance (GDSA)",
+    description:
+      "GSF is a member — contributing technical expertise to UK government digital sustainability strategy. Academic institutions with UK research profiles can engage with government digital policy via GSF membership.",
+    link: "/articles/the-green-software-foundation-joins-the-uk-government-digital-sustainability-alli/",
+    linkText: "Read about GDSA",
+  },
+];
+
+const researchProgramme = [
+  {
+    title: "AI Environmental Assessments",
+    date: "Ratified November 2025",
+    description:
+      "Key publication examining the environmental impact of AI systems — frameworks for assessing and reducing the carbon footprint of AI workloads. Co-authored with academic partners.",
+    link: "https://research-information.bris.ac.uk/en/publications/beyond-counting-carbon-ai-environmental-assessments-struggle-to-i/",
+    linkText: "Read the publication",
+  },
+  {
+    title: "Green AI Position Paper",
+    date: "Policy research",
+    description:
+      "Defines Green AI, assesses environmental impacts across the AI lifecycle, and outlines key actions for industry and policy. The foundational document for GSF's AI sustainability work.",
+    link: "/policy/research/green-ai-position-paper/",
+    linkText: "Read the paper",
+  },
+  {
+    title: "SCI for Foundation Models — Texas State University",
+    date: "GSF-funded academic study",
+    description:
+      "Independent academic study confirming SCI as an effective metric for measuring the carbon impact of AI software. Demonstrates the type of industry-funded academic research GSF facilitates.",
+    link: "/articles/texas-state-university-deems-gsf-sci-an-effective-metric-to-evaluate-the-carbon-i/",
+    linkText: "Read the article",
+  },
+  {
+    title: "Carbon-Aware Computing Whitepaper — UBS & Microsoft",
+    date: "Industry case study",
+    description:
+      "First enterprise-scale implementation of carbon-aware computing using SCI and the Carbon Aware SDK. Demonstrates avoidance of multiple metric tons of CO₂eq annually — a direct example of academic research methodology deployed at production scale.",
+    link: "/articles/carbon-aware-computing-whitepaper-how-ubs-succeeded-in-measuring-and-reducing-car/",
+    linkText: "Read the whitepaper",
   },
 ];
 
@@ -395,21 +564,125 @@ const membershipBenefits = [
       <p class="mx-auto mt-4 max-w-2xl text-center text-base text-primary-dark md:text-lg">
         GSF produces and maintains ISO-certified standards. The following specifications have active, open research needs.
       </p>
-      <div class="mt-12 grid gap-6 sm:grid-cols-2">
-        {standardsItems.map((item) => (
-          <div class="rounded-lg border bg-white p-5 shadow-sm">
-            <h3 class="text-lg font-bold text-primary">{item.title}</h3>
-            <p class="mt-2 text-sm text-gray-darker">{item.description}</p>
+
+      <!-- Software Standards Working Group -->
+      <div class="mt-12">
+        <div class="mb-6 flex items-center gap-4">
+          <h3 class="shrink-0 text-base font-extrabold uppercase tracking-wide text-primary-dark">Software Standards Working Group</h3>
+          <div class="h-px flex-1 bg-accent-lighter"></div>
+        </div>
+        <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {softwareStandards.map((item) => (
+            <div class="flex flex-col rounded-lg border bg-white p-5 shadow-sm">
+              <div class="mb-3 flex items-start justify-between gap-2">
+                <h4 class="text-base font-bold leading-snug text-primary-dark">{item.title}</h4>
+                <span class={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${item.statusColor}`}>{item.status}</span>
+              </div>
+              <p class="flex-1 text-sm leading-relaxed text-gray-darker">{item.description}</p>
+              {item.link && (
+                <a href={item.link} class="mt-3 inline-flex items-center text-sm font-semibold text-primary hover:underline">
+                  {item.linkText} →
+                </a>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <!-- Hardware Standards Working Group -->
+      <div class="mt-10">
+        <div class="mb-6 flex items-center gap-4">
+          <h3 class="shrink-0 text-base font-extrabold uppercase tracking-wide text-primary-dark">Hardware Standards Working Group</h3>
+          <div class="h-px flex-1 bg-accent-lighter"></div>
+        </div>
+        <div class="grid gap-5 sm:grid-cols-2">
+          {hardwareStandards.map((item) => (
+            <div class="flex flex-col rounded-lg border bg-white p-5 shadow-sm">
+              <div class="mb-3 flex items-start justify-between gap-2">
+                <h4 class="text-base font-bold leading-snug text-primary-dark">{item.title}</h4>
+                <span class={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${item.statusColor}`}>{item.status}</span>
+              </div>
+              <p class="flex-1 text-sm leading-relaxed text-gray-darker">{item.description}</p>
+              {item.link && (
+                <a href={item.link} class="mt-3 inline-flex items-center text-sm font-semibold text-primary hover:underline">
+                  {item.linkText} →
+                </a>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <!-- Cross-Cutting Research Areas -->
+      <div class="mt-10">
+        <div class="mb-6 flex items-center gap-4">
+          <h3 class="shrink-0 text-base font-extrabold uppercase tracking-wide text-primary-dark">Cross-Cutting Research Areas</h3>
+          <div class="h-px flex-1 bg-accent-lighter"></div>
+        </div>
+        <p class="mb-6 text-sm text-gray-darker">Active initiatives feeding into the standards pipeline — where academic collaboration is being actively sought.</p>
+        <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {crossCuttingAreas.map((item) => (
+            <div class="rounded-lg border border-dashed border-accent-lighter bg-white/60 p-5">
+              <h4 class="text-base font-bold text-primary-dark">{item.title}</h4>
+              <p class="mt-2 text-sm leading-relaxed text-gray-darker">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 5b: Active GSF Policy Engagements -->
+  <section class="bg-white py-16 md:py-20">
+    <div class="container">
+      <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Active GSF Policy Engagements</h2>
+      <p class="mt-4 max-w-2xl text-base text-primary-dark md:text-lg">
+        GSF participates directly in regulatory consultations and policy formation. Academic researchers working in these areas can contribute formal expertise via GSF membership.
+      </p>
+      <div class="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {policyEngagements.map((item) => (
+          <div class="flex flex-col rounded-lg border bg-accent-lightest-2 p-5">
+            <h3 class="text-base font-bold text-primary-dark">{item.title}</h3>
+            <p class="mt-2 flex-1 text-sm leading-relaxed text-gray-darker">{item.description}</p>
             {item.link && (
-              <a
-                href={item.link}
-                class="mt-3 inline-flex items-center text-sm font-bold text-primary hover:underline"
-              >
-                {item.linkText}
+              <a href={item.link} class="mt-3 inline-flex items-center text-sm font-semibold text-primary hover:underline">
+                {item.linkText} →
               </a>
             )}
           </div>
         ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 5c: Research Programme -->
+  <section class="bg-accent-lightest-2 py-16 md:py-20">
+    <div class="container">
+      <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">Research Programme</h2>
+      <p class="mt-4 max-w-2xl text-base text-primary-dark md:text-lg">
+        Selected publications and case studies from GSF's research programme — demonstrating the type of industry-linked academic work the Foundation facilitates.
+      </p>
+      <div class="mt-10 grid gap-5 sm:grid-cols-2">
+        {researchProgramme.map((item) => (
+          <div class="flex flex-col rounded-lg border bg-white p-6 shadow-sm">
+            <p class="text-xs font-semibold uppercase tracking-wide text-primary">{item.date}</p>
+            <h3 class="mt-2 text-base font-bold text-primary-dark">{item.title}</h3>
+            <p class="mt-2 flex-1 text-sm leading-relaxed text-gray-darker">{item.description}</p>
+            {item.link && (
+              <a href={item.link} class="mt-4 inline-flex items-center text-sm font-semibold text-primary hover:underline">
+                {item.linkText} →
+              </a>
+            )}
+          </div>
+        ))}
+      </div>
+      <div class="mt-8 text-center">
+        <a
+          href="/policy/research/"
+          class="inline-block rounded-lg border border-primary px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-primary hover:text-white"
+        >
+          Full publications library →
+        </a>
       </div>
     </div>
   </section>

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -718,16 +718,30 @@ const membershipBenefits = [
   <!-- Green AI Committee full-width section -->
   <section class="bg-primary py-16 md:py-20">
     <div class="container">
-      <!-- Header -->
+      <!-- Header + CTAs -->
       <div class="mb-10">
         <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">GSF Committee</p>
-        <h2 class="text-2xl font-extrabold text-white md:text-3xl lg:text-4xl">Green AI Committee</h2>
+        <h2 class="mb-6 text-2xl font-extrabold text-white md:text-3xl lg:text-4xl">Green AI Committee</h2>
+        <div class="flex flex-wrap gap-3">
+          <a
+            href="#submission-form"
+            class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
+          >
+            GSF Academic Members can join the Green AI Committee →
+          </a>
+          <a
+            href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
+            class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
+          >
+            EU AI Act analysis →
+          </a>
+        </div>
       </div>
 
-      <!-- Left-right layout: text left, members right -->
+      <!-- Left-right layout: text left (bottom-aligned), members right -->
       <div class="grid gap-10 lg:grid-cols-2 lg:gap-14">
-        <!-- Left: text boxes + CTAs -->
-        <div class="flex flex-col gap-5">
+        <!-- Left: text boxes pushed to bottom of grid row -->
+        <div class="flex flex-col justify-end gap-5">
           <div class="rounded-2xl bg-white/10 p-6">
             <p class="mb-3 text-xs font-bold uppercase tracking-widest text-accent">Policy &amp; Standards</p>
             <p class="text-base leading-relaxed text-white/90">
@@ -739,20 +753,6 @@ const membershipBenefits = [
             <p class="text-base leading-relaxed text-white/90">
               For academic researchers working at the intersection of AI, environmental assessment, and regulatory compliance, the Green AI Committee is the point of engagement — connecting academic expertise directly to the policy and standards processes where it carries weight.
             </p>
-          </div>
-          <div class="flex flex-wrap gap-3 pt-2">
-            <a
-              href="#submission-form"
-              class="inline-block rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-accent hover:text-primary-dark"
-            >
-              GSF Academic Members can join the Green AI Committee →
-            </a>
-            <a
-              href="/articles/the-eu-ai-act-insights-from-the-green-ai-committee/"
-              class="inline-block rounded-lg border border-white/60 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10"
-            >
-              EU AI Act analysis →
-            </a>
           </div>
         </div>
 

--- a/src/pages/membership/academic/index.astro
+++ b/src/pages/membership/academic/index.astro
@@ -710,42 +710,48 @@ const membershipBenefits = [
 
         <!-- Committee Members -->
         <div class="mt-14">
-          <div class="mb-10 flex items-center gap-4">
+          <div class="mb-8 flex items-center gap-4">
             <p class="shrink-0 text-xs font-bold uppercase tracking-widest text-white/50">Committee Members</p>
             <div class="h-px flex-1 bg-white/20"></div>
           </div>
 
           <!-- Co-chairs featured row -->
-          <div class="mb-6 grid gap-6 sm:grid-cols-2">
+          <div class="mb-6 grid gap-4 sm:grid-cols-2">
             {committeeWithLogos.filter(m => m.role === "Co-Chair").map((member) => (
-              <div class="flex flex-col items-center rounded-2xl bg-white p-8 text-center shadow-md">
-                <div class="flex h-28 w-28 items-center justify-center overflow-hidden rounded-2xl bg-white p-3 shadow-sm ring-1 ring-black/5">
-                  {member.logo ? (
-                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
-                  ) : (
-                    <span class="text-3xl font-extrabold text-primary">{member.initials}</span>
-                  )}
-                </div>
-                <span class="mt-5 inline-block rounded-full bg-accent px-3 py-1 text-xs font-bold text-primary-dark">Co-Chair</span>
-                <p class="mt-2 text-base font-extrabold text-primary-dark">{member.name}</p>
-                <p class="mt-1 text-sm text-gray-darker">{member.org}</p>
-              </div>
-            ))}
-          </div>
-
-          <!-- Regular members grid -->
-          <div class="grid gap-4 sm:grid-cols-3">
-            {committeeWithLogos.filter(m => m.role !== "Co-Chair").map((member) => (
-              <div class="flex flex-col items-center rounded-xl bg-white p-6 text-center shadow-sm">
-                <div class="flex h-20 w-20 items-center justify-center overflow-hidden rounded-xl bg-white p-2 shadow-sm ring-1 ring-black/5">
+              <div class="flex items-center gap-4 rounded-xl border border-white/20 bg-white p-5">
+                <div class="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-accent-lightest-2 p-2">
                   {member.logo ? (
                     <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
                   ) : (
                     <span class="text-xl font-extrabold text-primary">{member.initials}</span>
                   )}
                 </div>
-                <p class="mt-4 text-sm font-bold text-primary-dark">{member.name}</p>
-                <p class="mt-0.5 text-xs text-gray-darker">{member.org}</p>
+                <div class="min-w-0">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="text-sm font-extrabold text-primary-dark">{member.name}</p>
+                    <span class="rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-primary-dark">Co-Chair</span>
+                  </div>
+                  <p class="mt-0.5 text-xs text-gray-darker">{member.org}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <!-- Regular members grid -->
+          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {committeeWithLogos.filter(m => m.role !== "Co-Chair").map((member) => (
+              <div class="flex items-center gap-4 rounded-xl border border-white/20 bg-white p-4">
+                <div class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-accent-lightest-2 p-1.5">
+                  {member.logo ? (
+                    <img src={member.logo} alt={member.org} class="h-full w-full object-contain" loading="lazy" decoding="async" />
+                  ) : (
+                    <span class="text-sm font-extrabold text-primary">{member.initials}</span>
+                  )}
+                </div>
+                <div class="min-w-0">
+                  <p class="truncate text-sm font-semibold leading-tight text-primary-dark">{member.name}</p>
+                  <p class="truncate text-xs text-gray-darker">{member.org}</p>
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
Adds a dedicated landing page for academic membership in the Green Software Foundation, providing information about the programme, benefits, and how to enquire.

## Changes
- **New page:** `src/pages/membership/academic/index.astro` — comprehensive 450-line landing page covering:
  - Hero section with membership pitch and CTA
  - Member logos marquee for credibility
  - Five domains of GSF work (Software Standards, Hardware Standards, AI & Energy Efficiency, Policy & Regulation, Education & Tooling)
  - Eight membership benefits (working group participation, assembly access, proposal rights, co-authorship, consensus rights, curriculum licensing, no fees)
  - Discipline-to-project mapping table (9 research disciplines aligned with active GSF work)
  - List of 17 current academic member universities with locations
  - Institutional sustainability relevance section
  - Four complementary academic programmes (SE4GD, GREENER Principles, ARCHER2, Texas State research)
  - Four-step enquiry process
  - Five FAQ items with native `<details>` accordion
  - Final CTA banner

- **Navigation update:** `src/lib/nav-items.ts` — added "Academic Membership" link under About → For Members

- **Documentation:** `docs/pages/membership-academic.md` — page overview, update instructions, and content structure

## Implementation details
- Uses existing Astro components (Hero, FeatureGrid, ResourceCards, CTABanner, etc.)
- Responsive design with separate desktop table and mobile card layouts for data tables
- All content is static/hardcoded (intentional) except member logos which fetch from `src/data/members.json`
- Includes both desktop and mobile versions of two data tables (discipline mapping and university list)
- Links to enquiry form at `/membership/enquire/` and external resources (SE4GD, GREENER paper, ARCHER2, Texas State research)

https://claude.ai/code/session_01JrDXN74Cn6saFXV34R5SZm