### PR TITLE
Update SCI for AI course links and descriptions

### DIFF
--- a/src/pages/standards/sci-ai/index.astro
+++ b/src/pages/standards/sci-ai/index.astro
@@ -292,9 +292,9 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
   <!-- Take the Course -->
   <CTACard
     heading="Learn to measure AI's carbon footprint"
-    body="Take the SCI for AI course on the Movement Platform to understand how to apply the methodology to AI systems."
+    body="Take the SCI for AI Fundamentals course to understand how to apply the methodology to AI systems."
     ctaText="Take the course"
-    ctaHref="https://movement.greensoftware.foundation/spaces/23023497/page"
+    ctaHref="https://grnsft.org/sci-ai-fundamentals-course"
     imageSrc="/assets/ready.svg"
     imageAlt="SCI for AI course illustration"
   />

--- a/src/pages/standards/sci-ai/index.astro
+++ b/src/pages/standards/sci-ai/index.astro
@@ -70,7 +70,7 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
     body="AI systems have become increasingly resource-intensive, yet there's no consistent way to measure their environmental impact. SCI for AI changes that by building on <a href='https://sci.greensoftware.foundation/' class='text-primary underline' target='_blank' rel='noopener noreferrer'>ISO/IEC 21031:2024</a> — the world's first ISO standard for software carbon measurement — to provide a consensus-based standard that makes AI's carbon footprint transparent, comparable, and actionable."
     ctas={[
       { text: "Read the Specification", variant: "primary", href: "https://github.com/Green-Software-Foundation/sci-ai/blob/dev/SPEC.md" },
-      { text: "Get Involved", variant: "outline", href: "https://directory.greensoftware.foundation/projects/software-carbon-intensity-for-artificial-intelligence/" },
+      { text: "Take the Course", variant: "outline", href: "https://grnsft.org/sci-ai-fundamentals-course" },
     ]}
     imageSrc="/assets/standards/sci-ai/hero-illustration.svg"
     imageAlt="SCI for AI illustration"

--- a/src/pages/standards/sci/index.astro
+++ b/src/pages/standards/sci/index.astro
@@ -67,7 +67,7 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
     body="Every software application has a carbon footprint through the energy it consumes and the hardware it requires. The Software Carbon Intensity (SCI) specification provides the first ISO-accredited methodology to measure this impact as a score."
     ctas={[
       { text: "Read the Specification", variant: "primary", href: "https://grnsft.org/sci" },
-      { text: "Get Involved", variant: "outline", href: "https://directory.greensoftware.foundation/projects/software-carbon-intensity-(sci)/" },
+      { text: "Take the Course", variant: "outline", href: "https://grnsft.org/sci-fundamentals-course" },
     ]}
     imageSrc="/assets/standards/sci/hero-illustration.svg"
     imageAlt="SCI illustration"
@@ -371,6 +371,16 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
       },
     ]}
     bgClass="bg-accent-lightest-2"
+  />
+
+  <!-- Take the Course -->
+  <CTACard
+    heading="Learn to measure software's carbon footprint"
+    body="Take the SCI Fundamentals course to understand how to apply the methodology to your software systems."
+    ctaText="Take the course"
+    ctaHref="https://grnsft.org/sci-fundamentals-course"
+    imageSrc="/assets/ready.svg"
+    imageAlt="SCI course illustration"
   />
 
   <!-- Get Involved -->


### PR DESCRIPTION
## Summary
Updated course references and links throughout the SCI for AI page to point to the new SCI for AI Fundamentals course on the shortened domain.

## Key Changes
- Updated the hero section CTA button from "Get Involved" (linking to project directory) to "Take the Course" (linking to the fundamentals course)
- Changed the course card body text from "Movement Platform" reference to "SCI for AI Fundamentals course"
- Updated both course-related CTAs to use the new shortened URL: `https://grnsft.org/sci-ai-fundamentals-course`
  - Hero section CTA link
  - Course card CTA link

## Implementation Details
These changes consolidate the course promotion strategy by:
1. Replacing the generic "Get Involved" call-to-action with a more specific educational offering
2. Removing references to the Movement Platform in favor of a dedicated course URL
3. Using a consistent shortened domain link across both course promotion sections for better tracking and maintainability

https://claude.ai/code/session_01T2FNqhMngQ233TwSDBDCuf