### PR TITLE
Refine SCI Self Certification programme messaging and process

### DIFF
--- a/src/pages/standards/certification/index.astro
+++ b/src/pages/standards/certification/index.astro
@@ -6,7 +6,7 @@ import Navbar from "@/components/navbar.astro";
 import Hero from "@/components/hero.astro";
 import TextWithImage from "@/components/text-with-image.astro";
 import FeatureGrid from "@/components/feature-grid.astro";
-import CardGrid from "@/components/card-grid.astro";
+import CTABanner from "@/components/cta-banner.astro";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import Footer from "@/components/footer.astro";
 ---
@@ -36,11 +36,45 @@ import Footer from "@/components/footer.astro";
     headingAccent="Programme"
     body="A free programme for organisations to self-certify conformity with ISO/IEC 21031:2024 (Software Carbon Intensity). Submit your SCI methodology as a public disclosure — GSF reviews completeness, the community provides accountability."
     ctas={[
-      { text: "Explore the programme", variant: "primary", href: "https://github.com/Green-Software-Foundation/certification" },
+      { text: "Apply now", variant: "primary", href: "mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission" },
       { text: "Learn about SCI", variant: "outline", href: "/standards/sci/" },
     ]}
     imageSrc="/assets/ready.svg"
     imageAlt="SCI Certification illustration"
+    bgClass="bg-accent-lightest-2"
+  />
+
+  <!-- Why it matters -->
+  <TextWithImage
+    badge="WHY IT MATTERS"
+    heading="Measuring emissions is only"
+    headingAccent="the beginning"
+    body="When ISO/IEC 21031:2024 was published, organisations gained a rigorous methodology for calculating software carbon intensity — but internal measurement work isn’t visible outside the organisation. With regulations like CSRD extending their scope to include software emissions, and procurement requirements emerging, the expectation for consistent and verifiable disclosures is growing. Calculating your SCI score is the foundation; publicly disclosing it is what turns that work into accountability."
+    imageSrc="/assets/sustainability.svg"
+    imageAlt="Sustainability illustration"
+    bgClass="bg-white"
+  />
+
+  <!-- Benefits -->
+  <FeatureGrid
+    heading="Benefits at *every level*"
+    body="Every disclosure contributes to the shared body of reference data the industry needs to make meaningful progress on software sustainability."
+    variant="bordered"
+    columns={3}
+    features={[
+      {
+        title: "For your organisation",
+        description: "Brings internal measurement work into a publicly recognised disclosure — giving procurement teams, auditors, and regulators a consistent reference point as transparency requirements grow.",
+      },
+      {
+        title: "For your stakeholders",
+        description: "Provides a transparent, structured record of your software’s carbon intensity that clients, partners, and supply chain reviewers can incorporate into their own reporting with confidence.",
+      },
+      {
+        title: "For the industry",
+        description: "Each approved disclosure joins a publicly accessible body of methodology and results that researchers, benchmarkers, and policymakers can build on — turning individual measurement work into collective infrastructure.",
+      },
+    ]}
     bgClass="bg-accent-lightest-2"
   />
 
@@ -63,57 +97,11 @@ import Footer from "@/components/footer.astro";
     badge="ELIGIBILITY"
     heading="Open to"
     headingAccent="all"
-    body="SCI Self Certification is available to any organisation that has calculated an SCI score according to ISO/IEC 21031:2024. There are no membership requirements, fees, or restrictions on organisation size, type, or domain. The more organisations measuring and disclosing their software carbon intensity, the stronger the standard becomes. The programme is free — if you've measured your SCI score, you're ready to apply."
-    ctaText="Explore the programme →"
-    ctaHref="https://github.com/Green-Software-Foundation/certification"
+    body="SCI Self Certification is available to any organisation that has calculated an SCI score according to ISO/IEC 21031:2024. There are no membership requirements, fees, or restrictions on organisation size, type, or domain. The more organisations measuring and disclosing their software carbon intensity, the stronger the standard becomes. The programme is free — if you’ve measured your SCI score, you’re ready to apply."
+    ctaText="Apply now →"
+    ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
     imageSrc="/assets/about-gsf-illustration.svg"
     imageAlt="Open programme illustration"
-  />
-
-  <!-- What your submission covers -->
-  <TextWithImage
-    badge="WHAT YOUR SUBMISSION COVERS"
-    heading="A 7-section"
-    headingAccent="questionnaire"
-    imageSrc="/assets/standards/sci/why-feat-2.svg"
-    imageAlt="Submission coverage illustration"
-    reversed
-    iconFeatures={[
-      {
-        icon: "/assets/standards/sci/dive-icon-1.svg",
-        description: '<span class="font-extrabold">About you and your software</span> — organisation, contact, software name, version, and a brief description',
-      },
-      {
-        icon: "/assets/standards/sci/co2-icon.svg",
-        description: '<span class="font-extrabold">SCI score</span> — your score with units (e.g. gCO2eq per 1,000 API requests) and the measurement period',
-      },
-      {
-        icon: "/assets/standards/sci/infra-icon.svg",
-        description: '<span class="font-extrabold">Software boundary</span> — included components, excluded components with rationale, and how shared infrastructure is handled',
-      },
-      {
-        icon: "/assets/standards/sci/grid-icon.svg",
-        description: '<span class="font-extrabold">Functional unit (R)</span> — the unit you chose, why it reflects how your software scales or delivers value, and how you counted it',
-      },
-      {
-        icon: "/assets/standards/sci/transforming-icon-2.svg",
-        description: '<span class="font-extrabold">Energy and carbon intensity (E, I)</span> — total energy with PUE, per-component breakdown with data sources, and carbon intensity with location, approach, and source',
-      },
-      {
-        icon: "/assets/standards/sci/cost-icon.svg",
-        description: '<span class="font-extrabold">Embodied emissions (M)</span> — total M with unit (or a specific justification if M=0), plus per-component breakdown with sources if M>0',
-      },
-      {
-        icon: "/assets/standards/sci/dive-icon-3.svg",
-        description: '<span class="font-extrabold">Methodology and calculation</span> — approach (measurement, calculation, or hybrid), at least one specific assumption and limitation, and the full SCI calculation shown with your actual numbers',
-      },
-      {
-        icon: "/assets/standards/sci/check-icon.svg",
-        description: '<span class="font-extrabold">Attestation</span> — the 10-point attestation from the template, signed and dated',
-      },
-    ]}
-    iconFeaturesBgIcon="/assets/standards/sci/icon-bg.svg"
-    bgClass="bg-white"
   />
 
   <!-- How it works -->
@@ -151,35 +139,12 @@ import Footer from "@/components/footer.astro";
     bgClass="bg-accent-lightest-2"
   />
 
-  <!-- Get Involved -->
-  <CardGrid
-    heading="Get Involved"
-    body="Whether you're ready to apply, want to deepen your understanding of the SCI, or have a question, here's where to start."
-    columns={3}
-    cards={[
-      {
-        icon: "/assets/standards/sci/shape-icon-1.svg",
-        title: "Explore the Programme",
-        description: "Find the questionnaire, submission guidance, and everything you need to apply on GitHub.",
-        ctaText: "Visit the repository",
-        ctaHref: "https://github.com/Green-Software-Foundation/certification",
-      },
-      {
-        icon: "/assets/standards/sci/shape-icon-2.svg",
-        title: "Learn about the SCI",
-        description: "Take the free SCI Fundamentals course to understand the ISO/IEC 21031:2024 standard your certification will be based on.",
-        ctaText: "Take the course",
-        ctaHref: "https://grnsft.org/sci-fundamentals-course",
-      },
-      {
-        icon: "/assets/standards/sci/shape-icon-3.svg",
-        title: "Ask us anything",
-        description: "Have a question about eligibility, the questionnaire, or the process? Get in touch with the certification team.",
-        ctaText: "Email the team",
-        ctaHref: "mailto:sci-certification@greensoftware.foundation",
-      },
-    ]}
-    bgClass="bg-accent-lightest-2"
+  <!-- CTA -->
+  <CTABanner
+    heading="Interested in SCI Self Certification?"
+    body="Get in touch to learn more about applying and what's required. The programme is free and open to all — we'll walk you through the process."
+    ctaText="Email us to apply"
+    ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
   />
 
   <Footer />

--- a/src/pages/standards/certification/index.astro
+++ b/src/pages/standards/certification/index.astro
@@ -34,7 +34,7 @@ import Footer from "@/components/footer.astro";
   <Hero
     heading="SCI Self Certification"
     headingAccent="Programme"
-    body="A free programme for organisations to self-certify conformity with ISO/IEC 21031:2024 (Software Carbon Intensity). Submit your SCI methodology as a public disclosure — GSF reviews completeness, the community provides accountability."
+    body="Your SCI score only matters if it’s verifiable. The GSF Self-Certification Programme is the only free path to a publicly disclosed, GSF-issued certificate of ISO/IEC 21031:2024 conformity — open to any organisation, typically 3–4 weeks from submission to certificate."
     ctas={[
       { text: "Apply now", variant: "primary", href: "mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission" },
       { text: "Learn about SCI", variant: "outline", href: "/standards/sci/" },
@@ -97,7 +97,7 @@ import Footer from "@/components/footer.astro";
     badge="ELIGIBILITY"
     heading="Open to"
     headingAccent="all"
-    body="SCI Self Certification is available to any organisation that has calculated an SCI score according to ISO/IEC 21031:2024. There are no membership requirements, fees, or restrictions on organisation size, type, or domain. The more organisations measuring and disclosing their software carbon intensity, the stronger the standard becomes. The programme is free — if you’ve measured your SCI score, you’re ready to apply."
+    body="Already have an SCI score? You’re eligible. The programme is open to any organisation, regardless of size, sector, or GSF membership — no fees, no restrictions. Every organisation that joins gives the industry a more complete, verifiable picture of software’s carbon impact."
     ctaText="Apply now →"
     ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
     imageSrc="/assets/about-gsf-illustration.svg"
@@ -107,7 +107,7 @@ import Footer from "@/components/footer.astro";
   <!-- How it works -->
   <FeatureGrid
     heading="How *certification works*"
-    body="The programme is designed to be straightforward, with a typical turnaround of 3–4 weeks from submission to certificate."
+    body="From submission to certificate in typically 3–4 weeks. The process is lightweight by design — if your SCI calculation is done, most of the work is already done."
     variant="bordered"
     columns={3}
     features={[
@@ -141,8 +141,8 @@ import Footer from "@/components/footer.astro";
 
   <!-- CTA -->
   <CTABanner
-    heading="Interested in SCI Self Certification?"
-    body="Get in touch to learn more about applying and what's required. The programme is free and open to all — we'll walk you through the process."
+    heading="Ready to put your SCI score on the record?"
+    body="If you’ve calculated your SCI score, you’re ready to apply. Email us and we’ll send you the submission template — most applicants can prepare a complete submission in a few hours."
     ctaText="Email us to apply"
     ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
   />

--- a/src/pages/standards/certification/index.astro
+++ b/src/pages/standards/certification/index.astro
@@ -6,7 +6,7 @@ import Navbar from "@/components/navbar.astro";
 import Hero from "@/components/hero.astro";
 import TextWithImage from "@/components/text-with-image.astro";
 import FeatureGrid from "@/components/feature-grid.astro";
-import CTABanner from "@/components/cta-banner.astro";
+import CardGrid from "@/components/card-grid.astro";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import Footer from "@/components/footer.astro";
 ---
@@ -105,12 +105,35 @@ import Footer from "@/components/footer.astro";
     bgClass="bg-accent-lightest-2"
   />
 
-  <!-- CTA -->
-  <CTABanner
-    heading="Interested in SCI Self Certification?"
-    body="Explore the programme on GitHub to find the questionnaire, submission guidance, and everything you need to get started. The programme is free and open to all."
-    ctaText="Explore on GitHub"
-    ctaHref="https://github.com/Green-Software-Foundation/certification"
+  <!-- Get Involved -->
+  <CardGrid
+    heading="Get Involved"
+    body="Whether you're ready to apply, want to deepen your understanding of the SCI, or have a question, here's where to start."
+    columns={3}
+    cards={[
+      {
+        icon: "/assets/standards/sci/shape-icon-1.svg",
+        title: "Explore the Programme",
+        description: "Find the questionnaire, submission guidance, and everything you need to apply on GitHub.",
+        ctaText: "Visit the repository",
+        ctaHref: "https://github.com/Green-Software-Foundation/certification",
+      },
+      {
+        icon: "/assets/standards/sci/shape-icon-2.svg",
+        title: "Learn about the SCI",
+        description: "Take the free SCI Fundamentals course to understand the ISO/IEC 21031:2024 standard your certification will be based on.",
+        ctaText: "Take the course",
+        ctaHref: "https://grnsft.org/sci-fundamentals-course",
+      },
+      {
+        icon: "/assets/standards/sci/shape-icon-3.svg",
+        title: "Ask us anything",
+        description: "Have a question about eligibility, the questionnaire, or the process? Get in touch with the certification team.",
+        ctaText: "Email the team",
+        ctaHref: "mailto:sci-certification@greensoftware.foundation",
+      },
+    ]}
+    bgClass="bg-accent-lightest-2"
   />
 
   <Footer />

--- a/src/pages/standards/certification/index.astro
+++ b/src/pages/standards/certification/index.astro
@@ -36,7 +36,7 @@ import Footer from "@/components/footer.astro";
     headingAccent="Programme"
     body="A free programme for organisations to self-certify conformity with ISO/IEC 21031:2024 (Software Carbon Intensity). Submit your SCI methodology as a public disclosure — GSF reviews completeness, the community provides accountability."
     ctas={[
-      { text: "Apply now", variant: "primary", href: "mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission" },
+      { text: "Explore the programme", variant: "primary", href: "https://github.com/Green-Software-Foundation/certification" },
       { text: "Learn about SCI", variant: "outline", href: "/standards/sci/" },
     ]}
     imageSrc="/assets/ready.svg"
@@ -64,8 +64,8 @@ import Footer from "@/components/footer.astro";
     heading="Open to"
     headingAccent="all"
     body="SCI Self Certification is available to any organisation that has calculated an SCI score according to ISO/IEC 21031:2024. There are no membership requirements, fees, or restrictions on organisation size, type, or domain. The more organisations measuring and disclosing their software carbon intensity, the stronger the standard becomes. The programme is free — if you've measured your SCI score, you're ready to apply."
-    ctaText="Apply now →"
-    ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
+    ctaText="Explore the programme →"
+    ctaHref="https://github.com/Green-Software-Foundation/certification"
     imageSrc="/assets/about-gsf-illustration.svg"
     imageAlt="Open programme illustration"
   />
@@ -108,9 +108,9 @@ import Footer from "@/components/footer.astro";
   <!-- CTA -->
   <CTABanner
     heading="Interested in SCI Self Certification?"
-    body="Get in touch to learn more about applying and what's required. The programme is free and open to all — we'll walk you through the process."
-    ctaText="Email us to apply"
-    ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
+    body="Explore the programme on GitHub to find the questionnaire, submission guidance, and everything you need to get started. The programme is free and open to all."
+    ctaText="Explore on GitHub"
+    ctaHref="https://github.com/Green-Software-Foundation/certification"
   />
 
   <Footer />

--- a/src/pages/standards/certification/index.astro
+++ b/src/pages/standards/certification/index.astro
@@ -6,7 +6,7 @@ import Navbar from "@/components/navbar.astro";
 import Hero from "@/components/hero.astro";
 import TextWithImage from "@/components/text-with-image.astro";
 import FeatureGrid from "@/components/feature-grid.astro";
-import CTABanner from "@/components/cta-banner.astro";
+import CardGrid from "@/components/card-grid.astro";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import Footer from "@/components/footer.astro";
 ---
@@ -36,7 +36,7 @@ import Footer from "@/components/footer.astro";
     headingAccent="Programme"
     body="Your SCI score only matters if it’s verifiable. The GSF Self-Certification Programme is the only free path to a publicly disclosed, GSF-issued certificate of ISO/IEC 21031:2024 conformity — open to any organisation, typically 3–4 weeks from submission to certificate."
     ctas={[
-      { text: "Apply now", variant: "primary", href: "mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission" },
+      { text: "Explore the programme", variant: "primary", href: "https://github.com/Green-Software-Foundation/certification" },
       { text: "Learn about SCI", variant: "outline", href: "/standards/sci/" },
     ]}
     imageSrc="/assets/ready.svg"
@@ -98,10 +98,56 @@ import Footer from "@/components/footer.astro";
     heading="Open to"
     headingAccent="all"
     body="Already have an SCI score? You’re eligible. The programme is open to any organisation, regardless of size, sector, or GSF membership — no fees, no restrictions. Every organisation that joins gives the industry a more complete, verifiable picture of software’s carbon impact."
-    ctaText="Apply now →"
-    ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
+    ctaText="Explore the programme →"
+    ctaHref="https://github.com/Green-Software-Foundation/certification"
     imageSrc="/assets/about-gsf-illustration.svg"
     imageAlt="Open programme illustration"
+  />
+
+  <!-- What your submission covers -->
+  <TextWithImage
+    badge="WHAT YOUR SUBMISSION COVERS"
+    heading="A 7-section"
+    headingAccent="questionnaire"
+    imageSrc="/assets/standards/sci/why-feat-2.svg"
+    imageAlt="Submission coverage illustration"
+    reversed
+    iconFeatures={[
+      {
+        icon: "/assets/standards/sci/dive-icon-1.svg",
+        description: '<span class="font-extrabold">About you and your software</span> — organisation, contact, software name, version, and a brief description',
+      },
+      {
+        icon: "/assets/standards/sci/co2-icon.svg",
+        description: '<span class="font-extrabold">SCI score</span> — your score with units (e.g. gCO2eq per 1,000 API requests) and the measurement period',
+      },
+      {
+        icon: "/assets/standards/sci/infra-icon.svg",
+        description: '<span class="font-extrabold">Software boundary</span> — included components, excluded components with rationale, and how shared infrastructure is handled',
+      },
+      {
+        icon: "/assets/standards/sci/grid-icon.svg",
+        description: '<span class="font-extrabold">Functional unit (R)</span> — the unit you chose, why it reflects how your software scales or delivers value, and how you counted it',
+      },
+      {
+        icon: "/assets/standards/sci/transforming-icon-2.svg",
+        description: '<span class="font-extrabold">Energy and carbon intensity (E, I)</span> — total energy with PUE, per-component breakdown with data sources, and carbon intensity with location, approach, and source',
+      },
+      {
+        icon: "/assets/standards/sci/cost-icon.svg",
+        description: '<span class="font-extrabold">Embodied emissions (M)</span> — total M with unit (or a specific justification if M=0), plus per-component breakdown with sources if M>0',
+      },
+      {
+        icon: "/assets/standards/sci/dive-icon-3.svg",
+        description: '<span class="font-extrabold">Methodology and calculation</span> — approach (measurement, calculation, or hybrid), at least one specific assumption and limitation, and the full SCI calculation shown with your actual numbers',
+      },
+      {
+        icon: "/assets/standards/sci/check-icon.svg",
+        description: '<span class="font-extrabold">Attestation</span> — the 10-point attestation from the template, signed and dated',
+      },
+    ]}
+    iconFeaturesBgIcon="/assets/standards/sci/icon-bg.svg"
+    bgClass="bg-white"
   />
 
   <!-- How it works -->
@@ -139,12 +185,35 @@ import Footer from "@/components/footer.astro";
     bgClass="bg-accent-lightest-2"
   />
 
-  <!-- CTA -->
-  <CTABanner
-    heading="Ready to put your SCI score on the record?"
-    body="If you’ve calculated your SCI score, you’re ready to apply. Email us and we’ll send you the submission template — most applicants can prepare a complete submission in a few hours."
-    ctaText="Email us to apply"
-    ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
+  <!-- Get Involved -->
+  <CardGrid
+    heading="Get Involved"
+    body="Whether you’re ready to apply, want to deepen your understanding of the SCI, or have a question, here’s where to start."
+    columns={3}
+    cards={[
+      {
+        icon: "/assets/standards/sci/shape-icon-1.svg",
+        title: "Explore the Programme",
+        description: "Find the questionnaire, submission guidance, and everything you need to apply on GitHub.",
+        ctaText: "Visit the repository",
+        ctaHref: "https://github.com/Green-Software-Foundation/certification",
+      },
+      {
+        icon: "/assets/standards/sci/shape-icon-2.svg",
+        title: "Learn about the SCI",
+        description: "Take the free SCI Fundamentals course to understand the ISO/IEC 21031:2024 standard your certification will be based on.",
+        ctaText: "Take the course",
+        ctaHref: "https://grnsft.org/sci-fundamentals-course",
+      },
+      {
+        icon: "/assets/standards/sci/shape-icon-3.svg",
+        title: "Ask us anything",
+        description: "Have a question about eligibility, the questionnaire, or the process? Get in touch with the certification team.",
+        ctaText: "Email the team",
+        ctaHref: "mailto:sci-certification@greensoftware.foundation",
+      },
+    ]}
+    bgClass="bg-accent-lightest-2"
   />
 
   <Footer />

--- a/src/pages/standards/certification/index.astro
+++ b/src/pages/standards/certification/index.astro
@@ -13,7 +13,7 @@ import Footer from "@/components/footer.astro";
 
 <Layout
   title="SCI Self Certification Programme — Green Software Foundation"
-  description="A free programme for product-level SCI disclosure. Any organisation can certify that their software product's carbon intensity has been measured and disclosed following ISO/IEC 21031:2024."
+  description="A free programme for organisations to self-certify conformity with ISO/IEC 21031:2024. Submit a public disclosure of your SCI calculation — GSF reviews completeness, the community provides accountability."
 >
   <Navbar
     logoSrc="/assets/gsf-logo-full.svg"
@@ -34,9 +34,9 @@ import Footer from "@/components/footer.astro";
   <Hero
     heading="SCI Self Certification"
     headingAccent="Programme"
-    body="A free programme for product-level SCI disclosure. Any organisation can certify that their software product's carbon intensity has been measured and disclosed following ISO/IEC 21031:2024."
+    body="A free programme for organisations to self-certify conformity with ISO/IEC 21031:2024 (Software Carbon Intensity). Submit your SCI methodology as a public disclosure — GSF reviews completeness, the community provides accountability."
     ctas={[
-      { text: "Apply now", variant: "primary", href: "mailto:help@greensoftware.foundation?subject=SCI%20Self%20Certification%20Application" },
+      { text: "Apply now", variant: "primary", href: "mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission" },
       { text: "Learn about SCI", variant: "outline", href: "/standards/sci/" },
     ]}
     imageSrc="/assets/ready.svg"
@@ -65,7 +65,7 @@ import Footer from "@/components/footer.astro";
     headingAccent="all"
     body="SCI Self Certification is available to any organisation that has calculated an SCI score according to ISO/IEC 21031:2024. There are no membership requirements, fees, or restrictions on organisation size, type, or domain. The more organisations measuring and disclosing their software carbon intensity, the stronger the standard becomes. The programme is free — if you've measured your SCI score, you're ready to apply."
     ctaText="Apply now →"
-    ctaHref="mailto:help@greensoftware.foundation?subject=SCI%20Self%20Certification%20Application"
+    ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
     imageSrc="/assets/about-gsf-illustration.svg"
     imageAlt="Open programme illustration"
   />
@@ -73,29 +73,29 @@ import Footer from "@/components/footer.astro";
   <!-- How it works -->
   <FeatureGrid
     heading="How *certification works*"
-    body="The programme is designed to be straightforward. Certificates are valid for one year, after which resubmission is required."
+    body="The programme is designed to be straightforward, with a typical turnaround of 3–4 weeks from submission to certificate."
     variant="bordered"
     columns={3}
     features={[
       {
         title: "1. Self-attestation questionnaire",
-        description: "The applicant completes a questionnaire confirming their SCI methodology, scope, and data sources. Liability for accuracy sits with the applicant.",
+        description: "The applicant completes a 7-section questionnaire covering their SCI methodology, boundary, functional unit, energy and carbon data, embodied emissions, and full calculation. A signed attestation is included. Liability for accuracy sits with the applicant.",
       },
       {
         title: "2. Completeness review",
-        description: "GSF staff check that the submission is complete. An AI-assisted filter may be used to speed up this step.",
+        description: "A reviewer assesses the submission against a 7-item checklist, asking whether each section is detailed enough for a practitioner to understand and evaluate the calculation. Review takes 10–15 business days. Incomplete submissions receive specific revision feedback — this is not a rejection.",
       },
       {
-        title: "3. Working group review",
-        description: "The Software Standards Working Group has the opportunity to review the submission and raise any objections.",
+        title: "3. SWG sign-off",
+        description: "The Software Standards Working Group has a 7-day objection period. Any member may raise a specific objection; in practice, most submissions proceed without one. This is a governance safeguard, not a full technical review.",
       },
       {
         title: "4. Sign-off",
-        description: "The GSF Executive Director or Chair reviews the outcome of the working group review and signs the certificate.",
+        description: "The GSF Executive Director or Chair reviews the outcome of the working group sign-off period and issues the certificate.",
       },
       {
         title: "5. Publication",
-        description: "The certificate is issued and published at the agreed disclosure level — covering at minimum the product name, organisation, date, and signatory.",
+        description: "The certificate is issued and the full submission is published publicly on GitHub. Your contact email is redacted; everything else is published as submitted. Public disclosure is what gives self-certification its credibility — anyone can read and assess your methodology.",
       },
       {
         title: "6. Annual renewal",
@@ -110,7 +110,7 @@ import Footer from "@/components/footer.astro";
     heading="Interested in SCI Self Certification?"
     body="Get in touch to learn more about applying and what's required. The programme is free and open to all — we'll walk you through the process."
     ctaText="Email us to apply"
-    ctaHref="mailto:help@greensoftware.foundation?subject=SCI%20Self%20Certification%20Application"
+    ctaHref="mailto:sci-certification@greensoftware.foundation?subject=SCI%20Self-Certification%20Submission"
   />
 
   <Footer />

--- a/src/pages/standards/certification/index.astro
+++ b/src/pages/standards/certification/index.astro
@@ -70,6 +70,52 @@ import Footer from "@/components/footer.astro";
     imageAlt="Open programme illustration"
   />
 
+  <!-- What your submission covers -->
+  <TextWithImage
+    badge="WHAT YOUR SUBMISSION COVERS"
+    heading="A 7-section"
+    headingAccent="questionnaire"
+    imageSrc="/assets/standards/sci/why-feat-2.svg"
+    imageAlt="Submission coverage illustration"
+    reversed
+    iconFeatures={[
+      {
+        icon: "/assets/standards/sci/dive-icon-1.svg",
+        description: '<span class="font-extrabold">About you and your software</span> — organisation, contact, software name, version, and a brief description',
+      },
+      {
+        icon: "/assets/standards/sci/co2-icon.svg",
+        description: '<span class="font-extrabold">SCI score</span> — your score with units (e.g. gCO2eq per 1,000 API requests) and the measurement period',
+      },
+      {
+        icon: "/assets/standards/sci/infra-icon.svg",
+        description: '<span class="font-extrabold">Software boundary</span> — included components, excluded components with rationale, and how shared infrastructure is handled',
+      },
+      {
+        icon: "/assets/standards/sci/grid-icon.svg",
+        description: '<span class="font-extrabold">Functional unit (R)</span> — the unit you chose, why it reflects how your software scales or delivers value, and how you counted it',
+      },
+      {
+        icon: "/assets/standards/sci/transforming-icon-2.svg",
+        description: '<span class="font-extrabold">Energy and carbon intensity (E, I)</span> — total energy with PUE, per-component breakdown with data sources, and carbon intensity with location, approach, and source',
+      },
+      {
+        icon: "/assets/standards/sci/cost-icon.svg",
+        description: '<span class="font-extrabold">Embodied emissions (M)</span> — total M with unit (or a specific justification if M=0), plus per-component breakdown with sources if M>0',
+      },
+      {
+        icon: "/assets/standards/sci/dive-icon-3.svg",
+        description: '<span class="font-extrabold">Methodology and calculation</span> — approach (measurement, calculation, or hybrid), at least one specific assumption and limitation, and the full SCI calculation shown with your actual numbers',
+      },
+      {
+        icon: "/assets/standards/sci/check-icon.svg",
+        description: '<span class="font-extrabold">Attestation</span> — the 10-point attestation from the template, signed and dated',
+      },
+    ]}
+    iconFeaturesBgIcon="/assets/standards/sci/icon-bg.svg"
+    bgClass="bg-white"
+  />
+
   <!-- How it works -->
   <FeatureGrid
     heading="How *certification works*"


### PR DESCRIPTION
## Summary
Updated the SCI Self Certification programme page to provide clearer, more detailed messaging about the certification process, timeline, and requirements. Changes reflect a more transparent and structured approach to the programme with specific procedural details.

## Key Changes

- **Updated page description and hero messaging** to emphasize self-certification of conformity with ISO/IEC 21031:2024 and highlight public disclosure and community accountability
- **Changed contact email** from `help@greensoftware.foundation` to `sci-certification@greensoftware.foundation` across all CTA links for better routing
- **Refined "How it works" section** with more specific procedural details:
  - Step 1: Expanded questionnaire description to detail the 7-section structure and signed attestation requirement
  - Step 2: Replaced vague "completeness check" with specific 7-item checklist criteria and 10–15 business day timeline; clarified that incomplete submissions receive revision feedback rather than rejection
  - Step 3: Renamed "Working group review" to "SWG sign-off" and clarified it's a 7-day objection period, not a full technical review
  - Step 4: Updated to reference "sign-off period" instead of "review"
  - Step 5: Changed publication details to specify full submission published on GitHub with redacted contact email
- **Added timeline information** noting typical 3–4 week turnaround from submission to certificate
- **Clarified annual renewal requirement** in the existing step 6

## Notable Details
These changes make the certification process more transparent by specifying timelines, review criteria, and publication practices, helping applicants understand exactly what to expect when submitting.

https://claude.ai/code/session_016bm418J4PVtRZoLgFG5wvV