### PR TITLE
Refine SCI certification page copy and formatting

### DIFF
--- a/src/pages/standards/certification/index.astro
+++ b/src/pages/standards/certification/index.astro
@@ -12,8 +12,8 @@ import Footer from "@/components/footer.astro";
 ---
 
 <Layout
-  title="SCI Self Certification Programme — Green Software Foundation"
-  description="A free programme for organisations to self-certify conformity with ISO/IEC 21031:2024. Submit a public disclosure of your SCI calculation — GSF reviews completeness, the community provides accountability."
+  title="SCI Self-Certification Programme — Green Software Foundation"
+  description="A free programme for organisations to self-certify conformity with ISO/IEC 21031:2024. Submit a public disclosure of your SCI calculation: GSF reviews completeness, the community provides accountability."
 >
   <Navbar
     logoSrc="/assets/gsf-logo-full.svg"
@@ -32,9 +32,9 @@ import Footer from "@/components/footer.astro";
 
   <!-- Hero -->
   <Hero
-    heading="SCI Self Certification"
+    heading="SCI Self-Certification"
     headingAccent="Programme"
-    body="Your SCI score only matters if it’s verifiable. The GSF Self-Certification Programme is the only free path to a publicly disclosed, GSF-issued certificate of ISO/IEC 21031:2024 conformity — open to any organisation, typically 3–4 weeks from submission to certificate."
+    body="Your SCI score only matters if it’s verifiable. The GSF Self-Certification Programme is the only free path to a publicly disclosed, GSF-issued certificate of ISO/IEC 21031:2024 conformity, open to any organisation, typically 3–4 weeks from submission to certificate."
     ctas={[
       { text: "Explore the programme", variant: "primary", href: "https://github.com/Green-Software-Foundation/certification" },
       { text: "Learn about SCI", variant: "outline", href: "/standards/sci/" },
@@ -49,7 +49,7 @@ import Footer from "@/components/footer.astro";
     badge="WHY IT MATTERS"
     heading="Measuring emissions is only"
     headingAccent="the beginning"
-    body="When ISO/IEC 21031:2024 was published, organisations gained a rigorous methodology for calculating software carbon intensity — but internal measurement work isn’t visible outside the organisation. With regulations like CSRD extending their scope to include software emissions, and procurement requirements emerging, the expectation for consistent and verifiable disclosures is growing. Calculating your SCI score is the foundation; publicly disclosing it is what turns that work into accountability."
+    body="When ISO/IEC 21031:2024 was published, organisations gained a rigorous methodology for calculating software carbon intensity, but internal measurement work isn’t visible outside the organisation. With regulations like the Corporate Sustainability Reporting Directive (CSRD) extending their scope to include software emissions, and procurement requirements emerging, the expectation for consistent and verifiable disclosures is growing. Calculating your SCI score is the foundation; publicly disclosing it is what turns that work into accountability."
     imageSrc="/assets/sustainability.svg"
     imageAlt="Sustainability illustration"
     bgClass="bg-white"
@@ -83,7 +83,7 @@ import Footer from "@/components/footer.astro";
     badge="WHAT WE CERTIFY"
     heading="The disclosure, not"
     headingAccent="the score"
-    body="GSF certifies that an organisation has completed and publicly disclosed an SCI calculation with sufficient detail for the community to understand and evaluate it. We verify that all required information is present — not that the methodology is sound, the arithmetic is correct, or the score is accurate. Responsibility for accuracy and conformity with ISO/IEC 21031:2024 sits entirely with the applicant through self-attestation. This keeps the programme lightweight and accessible while public disclosure provides the credibility — anyone can read your submission and assess it for themselves."
+    body="GSF certifies that an organisation has completed and publicly disclosed an SCI calculation with sufficient detail for the community to understand and evaluate it. We verify that all required information is present, not that the methodology is sound, the arithmetic is correct, or the score is accurate. Responsibility for accuracy and conformity with ISO/IEC 21031:2024 sits entirely with the applicant through self-attestation. This keeps the programme lightweight and accessible while public disclosure provides the credibility: anyone can read your submission and assess it for themselves."
     ctaText="Read the SCI specification →"
     ctaHref="/standards/sci/"
     imageSrc="/assets/values-maximise-trust.svg"
@@ -166,7 +166,7 @@ import Footer from "@/components/footer.astro";
         description: "A reviewer assesses the submission against a 7-item checklist, asking whether each section is detailed enough for a practitioner to understand and evaluate the calculation. Review takes 10–15 business days. Incomplete submissions receive specific revision feedback — this is not a rejection.",
       },
       {
-        title: "3. SWG sign-off",
+        title: "3. Software Standards Working Group sign-off",
         description: "The Software Standards Working Group has a 7-day objection period. Any member may raise a specific objection; in practice, most submissions proceed without one. This is a governance safeguard, not a full technical review.",
       },
       {


### PR DESCRIPTION
## Summary
This PR updates the SCI Self-Certification Programme page with refined copy, improved punctuation, and expanded terminology for clarity and consistency.

## Key Changes
- **Hyphenation**: Changed "Self Certification" to "Self-Certification" throughout the page for proper compound adjective formatting
- **Punctuation refinements**: 
  - Updated em dashes to commas in several descriptions for better readability
  - Changed em dash to colon in the "What We Certify" section for improved flow
- **Terminology expansion**: Expanded "CSRD" to "Corporate Sustainability Reporting Directive (CSRD)" for clarity to readers unfamiliar with the acronym
- **Acronym clarification**: Expanded "SWG" to "Software Standards Working Group" in the process timeline for better accessibility

## Notable Details
All changes are content-focused with no structural modifications to the component. The updates improve readability and professional presentation while maintaining the original meaning and intent of the messaging.

https://claude.ai/code/session_01HCyxYoK8G7TRn7fH1AXcRB