### PR TITLE
Update Policy Working Group leadership team

### DIFF
--- a/docs/pages/policy.md
+++ b/docs/pages/policy.md
@@ -11,10 +11,11 @@ The Policy Working Group's work: leadership, Policy Radar, policy engagement res
 
 ### Leadership photos
 
-Two leaders are hardcoded by name and looked up in `src/data/people.json`:
+Three leaders are hardcoded by name and looked up in `src/data/people.json`:
 
 - **Chris Adams** — Chair, Policy Working Group
-- **Joseph Cook** — Head of Research
+- **Ryan Sholin** — Co-Chair, Policy Working Group (Electricity Maps)
+- **Sean Mcilroy** — Programme Director, Green Software Foundation
 
 Photos and other metadata resolve from `people.json`. See [people component doc](../components/people.md).
 

--- a/src/pages/policy/index.astro
+++ b/src/pages/policy/index.astro
@@ -18,7 +18,8 @@ import { articleUrl } from "@/lib/utils";
 
 // ----- Leadership photos from team.json -----
 const chrisAdams = teamData.find((p: any) => p.fullName === "Chris Adams");
-const josephCook = teamData.find((p: any) => p.fullName === "Joseph Cook");
+const ryanSholin = teamData.find((p: any) => p.fullName === "Ryan Sholin");
+const seanMcilroy = teamData.find((p: any) => p.fullName === "Sean Mcilroy");
 
 // ----- Articles tagged "policy" or "research" for the carousel -----
 const allArticles = await getCollection("articles", (a) => a.data.published !== false);
@@ -80,14 +81,15 @@ const policyArticles = allArticles
           <span class="font-bold text-primary">Leadership</span>
         </h2>
         <p class="mt-4 text-lg leading-relaxed text-primary-dark/80">
-          The Policy Working Group is chaired by Chris Adams. Research is led by Joseph Cook.
+          The Policy Working Group is chaired by Chris Adams and co-chaired by Ryan Sholin.
         </p>
       </div>
 
-      <div class="mx-auto mt-10 grid max-w-3xl gap-8 md:grid-cols-2">
+      <div class="mx-auto mt-10 grid max-w-5xl gap-8 md:grid-cols-3">
         {[
           { person: chrisAdams, name: "Chris Adams", role: "Chair, Policy Working Group", org: "Green Web Foundation", title: "Director of Technology and Policy" },
-          { person: josephCook, name: "Joseph Cook", role: "Head of Research", org: "Green Software Foundation", title: "Head of Research" },
+          { person: ryanSholin, name: "Ryan Sholin", role: "Co-Chair, Policy Working Group", org: "Electricity Maps", title: "Advocacy Lead" },
+          { person: seanMcilroy, name: "Sean Mcilroy", role: "Programme Director", org: "Green Software Foundation", title: "Programme Director" },
         ].map(({ person, name, role, org, title }) => (
           <div class="flex flex-col items-center text-center">
             <div class="h-28 w-28 overflow-hidden rounded-full border-2 border-primary-lighter bg-accent-lightest-2">


### PR DESCRIPTION
## Summary
Updates the Policy Working Group leadership section to reflect current team structure, replacing Joseph Cook with Ryan Sholin (co-chair) and Sean Mcilroy (programme director).

## Changes
- **Leadership data**: Replaced `josephCook` lookup with `ryanSholin` and added `seanMcilroy` from team data
- **Leadership description**: Updated text to reflect Chris Adams as chair and Ryan Sholin as co-chair
- **Leadership grid**: Expanded from 2-column to 3-column layout (`max-w-3xl` → `max-w-5xl`, `md:grid-cols-2` → `md:grid-cols-3`)
- **Team cards**: 
  - Updated Joseph Cook card to Ryan Sholin (Co-Chair, Policy Working Group at Electricity Maps)
  - Added Sean Mcilroy card (Programme Director at Green Software Foundation)
- **Documentation**: Updated `docs/pages/policy.md` to reflect three leaders instead of two

## Implementation Details
The changes follow the existing pattern of hardcoding leader names and looking them up in `src/data/people.json`. Photos and metadata resolve automatically from the data file. The grid layout adjustment accommodates the additional team member while maintaining visual balance.

https://claude.ai/code/session_01U9wVkA3DikaLLtWHMCovLu