### PR TITLE
Allow bot actors in Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: '*'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

- Adds `allowed_bots: '*'` to the Claude Code Review workflow so PRs opened by the Claude bot are not blocked by the default actor check.

## Why

The `claude-code-review.yml` workflow was failing with _"Workflow initiated by non-human actor: claude (type: Bot)"_ on PRs opened by Claude. This one-line change allows bot-authored PRs to be reviewed normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcavSGDaomeUJFi5ArWodR)_