### PR TITLE
Support images in Assembly page body content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ public/pagefind/
 public/assets/logos/
 public/assets/project-icons/
 public/assets/team/
+public/assets/assembly-images/
 src/data/
 # @netlify/plugin-gatsby ignores start
 netlify/functions/gatsby

--- a/DEVLOG
+++ b/DEVLOG
@@ -762,3 +762,22 @@ The photo bug was more subtle. After re-fetching with fresh data, team photos we
 ### Reflections
 
 This session was a satisfying data-plumbing session. The Notion roll-up photo limitation was an excellent example of why you need to test with real data, not just check that the code looks right — the API response structure was correct but deliberately incomplete. The `logos.json` cleanup was a good reminder that derived files add maintenance surface: when the source changes, the derived file silently becomes stale.
+
+## 2026-07-01 - Assembly Page Images Fix
+
+**Objective**: Fix a bug report — images placed in an Assembly's Notion page body (e.g. the SCI for Open Telemetry assembly) weren't showing on the live detail page.
+
+### What We Found
+
+`blockToHtml()` in `scripts/fetch-notion-data.cjs`, which converts an Assembly's Notion page body into the `detailsHtml` field, only handled `paragraph`, `heading_1/2/3`, list items, `to_do`, and `divider` block types. Any `image` block fell through to the `default` case and was dropped before it ever reached `assemblies.json` — not an expired-URL or rendering bug, the image was simply never captured.
+
+### What We Built
+
+- **`image` case in `blockToHtml()`** — resolves the block's external or Notion-hosted file URL, downloads it via the existing `downloadFile()` helper (same pattern as member logos/team photos/project icons) to a new `ASSEMBLY_IMAGES_DIR`, and emits an `<img>` (wrapped in `<figure>`/`<figcaption>` when the block has a caption).
+- **`blockToHtml()` made async** — needed since the download is asynchronous; the call site now does `await Promise.all(blocks.map(blockToHtml))` instead of a plain `.map()`.
+- **`public/assets/assembly-images/`** — new gitignored output directory, created alongside the other Notion-fetched asset directories in `main()`.
+- Updated `docs/notion.md` and `docs/pages/assemblies.md` to document image support and note which block types remain unsupported (video, embed, callout, table, etc. still silently drop).
+
+### Next Steps
+
+- Re-run `npm run fetch-notion` (or `build:full`) to backfill `detailsHtml` for existing assemblies, including SCI for Open Telemetry.

--- a/docs/notion.md
+++ b/docs/notion.md
@@ -32,8 +32,9 @@ All dynamic site data is fetched from Notion via `scripts/fetch-notion-data.cjs`
 | Member logos | `public/assets/logos/` | Members DB `Logo` field |
 | Team/volunteer photos | `public/assets/team/` | Volunteers DB `Photo` field |
 | Project icons | `public/assets/project-icons/` | PWCIs DB icon/image fields |
+| Assembly page-body images | `public/assets/assembly-images/` | Assemblies DB page body `image` blocks |
 
-All three asset directories are gitignored — assets are fetched fresh from Notion at build time. This ensures that updates made in Notion (e.g. a new logo or updated project icon) are always picked up on the next build rather than being masked by stale files in Git.
+All asset directories are gitignored — assets are fetched fresh from Notion at build time. This ensures that updates made in Notion (e.g. a new logo or updated project icon) are always picked up on the next build rather than being masked by stale files in Git.
 
 ## How to Refresh Data
 
@@ -121,7 +122,7 @@ Person data for subscription-based people (name, title, LinkedIn, member org) is
 - `Start Date`, `End Date`, `Applications Open`, `Application Deadline` (date)
 - `Seats`, `Average Attendees` (number)
 - `Project` (relation), `Working Group` (relation) — links to PWCIs
-- Page body: content below a "Details" heading is extracted as rich HTML
+- Page body: content below a "Details" heading is extracted as rich HTML (paragraphs, headings, lists, to-dos, dividers, and images — images are downloaded to `public/assets/assembly-images/` since Notion's file URLs expire)
 
 ### Press Mentions DB
 

--- a/docs/pages/assemblies.md
+++ b/docs/pages/assemblies.md
@@ -29,7 +29,7 @@ The index page has these sections in order:
 
 All assembly data comes from `src/data/assemblies.json`, fetched from the Notion Assemblies database. See [Notion doc](../notion.md) for database properties.
 
-The fetch script also extracts the Notion page body content: anything below a "Details" heading is converted to HTML and stored in the `detailsHtml` field.
+The fetch script also extracts the Notion page body content: anything below a "Details" heading is converted to HTML and stored in the `detailsHtml` field. Supported block types are paragraphs, headings, bulleted/numbered lists, to-dos, dividers, and images. Images embedded in the page body are downloaded and rehosted to `public/assets/assembly-images/` (Notion's own file URLs expire after about an hour, so they can't be linked to directly) — see [Notion doc](../notion.md) for details. Unsupported block types (video, embed, callout, table, etc.) are silently dropped.
 
 ## Status Values and Visibility
 

--- a/scripts/fetch-notion-data.cjs
+++ b/scripts/fetch-notion-data.cjs
@@ -74,6 +74,7 @@ const DATA_DIR = path.join(ROOT_DIR, "src", "data");
 const LOGOS_DIR = path.join(ROOT_DIR, "public", "assets", "logos");
 const PHOTOS_DIR = path.join(ROOT_DIR, "public", "assets", "team");
 const PROJECT_ICONS_DIR = path.join(ROOT_DIR, "public", "assets", "project-icons");
+const ASSEMBLY_IMAGES_DIR = path.join(ROOT_DIR, "public", "assets", "assembly-images");
 
 // Pass --force to re-download all images even if they already exist on disk
 const FORCE_DOWNLOAD = process.argv.includes("--force");
@@ -829,9 +830,10 @@ async function fetchProjects() {
 
 /**
  * Convert a Notion block to simple HTML.
- * Supports paragraph, headings, bulleted/numbered lists, and to_do blocks.
+ * Supports paragraph, headings, bulleted/numbered lists, to_do, divider, and image blocks.
+ * Images are downloaded and rehosted to ASSEMBLY_IMAGES_DIR since Notion-hosted file URLs expire.
  */
-function blockToHtml(block) {
+async function blockToHtml(block) {
   const richTextToHtml = (rt) => {
     if (!rt || !Array.isArray(rt)) return "";
     return rt.map((t) => {
@@ -863,6 +865,18 @@ function blockToHtml(block) {
       return `<li>${richTextToHtml(block.to_do?.rich_text)}</li>`;
     case "divider":
       return "<hr />";
+    case "image": {
+      const image = block.image;
+      const url = image?.type === "external" ? image.external?.url : image?.file?.url;
+      if (!url) return "";
+      const savedName = await downloadFile(url, ASSEMBLY_IMAGES_DIR, block.id);
+      if (!savedName) return "";
+      const alt = (image.caption || []).map((t) => t.plain_text).join("")
+        .replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+      const img = `<img src="/assets/assembly-images/${savedName}" alt="${alt}" loading="lazy" />`;
+      const caption = richTextToHtml(image.caption);
+      return caption ? `<figure>${img}<figcaption>${caption}</figcaption></figure>` : img;
+    }
     default:
       return "";
   }
@@ -969,7 +983,7 @@ async function fetchAssemblies() {
         cursor = resp.has_more ? resp.next_cursor : undefined;
       } while (cursor);
 
-      const htmlParts = blocks.map(blockToHtml);
+      const htmlParts = await Promise.all(blocks.map(blockToHtml));
       const html = wrapListItems(htmlParts, blocks);
       if (html.trim()) detailsHtml = html;
     } catch (err) {
@@ -1039,6 +1053,7 @@ async function main() {
   fs.mkdirSync(LOGOS_DIR, { recursive: true });
   fs.mkdirSync(PHOTOS_DIR, { recursive: true });
   fs.mkdirSync(PROJECT_ICONS_DIR, { recursive: true });
+  fs.mkdirSync(ASSEMBLY_IMAGES_DIR, { recursive: true });
 
   // --- Members + Volunteers (parallel) ---
   // Two independent DB fetches run concurrently:


### PR DESCRIPTION
## Summary

Fixed a bug where images embedded in an Assembly's Notion page body were being silently dropped during the fetch process. Images are now downloaded and rehosted to `public/assets/assembly-images/` (since Notion's file URLs expire after ~1 hour) and rendered as `<img>` or `<figure>` elements in the `detailsHtml` field.

## Changes

- **`blockToHtml()` function** — added `image` case to handle both external and Notion-hosted file URLs; made the function `async` to support asynchronous file downloads
- **Image handling** — downloads images via the existing `downloadFile()` helper, emits `<img>` tags with lazy loading, wraps in `<figure>`/`<figcaption>` when captions are present
- **New asset directory** — `public/assets/assembly-images/` created and gitignored alongside other Notion-fetched asset directories
- **Call site update** — changed `blocks.map(blockToHtml)` to `await Promise.all(blocks.map(blockToHtml))` in `fetchAssemblies()` to handle async block conversion
- **Documentation** — updated `docs/notion.md` and `docs/pages/assemblies.md` to document image support and note which block types remain unsupported (video, embed, callout, table, etc.)
- **DEVLOG entry** — documented the bug, fix, and next steps

## Implementation Details

- Images are downloaded using the same pattern as member logos, team photos, and project icons
- Alt text is properly escaped for HTML attributes
- Captions are preserved as `<figcaption>` when present
- Unsupported block types continue to silently drop (as before)

https://claude.ai/code/session_018GKoRr67ykTcYco527HKoL