### PR TITLE
Add SCI for OpenTelemetry project landing page

### DIFF
--- a/docs/pages/sci-for-opentelemetry.md
+++ b/docs/pages/sci-for-opentelemetry.md
@@ -6,7 +6,7 @@ Project page for SCI for OpenTelemetry at `/tools/sci-for-opentelemetry/`.
 
 ## What the Page Shows
 
-A short landing page for the SCI for OpenTelemetry project — a new GSF project (convened with Sarah Hsu) developing draft OpenTelemetry semantic conventions for the Software Carbon Intensity (SCI) specification. The project hasn't started yet, so the page is deliberately brief: the problem it addresses, the SCI formula components it will standardise, and who's being recruited to work on it.
+A short landing page for the SCI for OpenTelemetry project — a new GSF project (convened with Sarah Hsu) bringing Software Carbon Intensity (SCI) to OpenTelemetry. The project's scope is bigger than just drafting semantic conventions: it starts with a draft set of semantic conventions (the Assembly's deliverable), then builds the instrumentation that puts them into practice. The page copy reflects both phases — don't reduce it back to "drafting semantic conventions" only. The project hasn't started yet, so the page is deliberately brief: the problem it addresses, the SCI formula components it will standardise, and who's being recruited to work on it.
 
 ## Dynamic Elements
 
@@ -28,7 +28,7 @@ Everything else is hardcoded in the page file (in page order):
 - Hero — heading/body copy written in the same format as `/standards/sci/`'s hero (statement heading + accent phrase + single body paragraph, no separate subtitle), reuses the SCI page's illustration (`/assets/standards/sci/hero-illustration.svg`), CTAs to the Assembly application page and the SCI specification
 - "Starting with an Assembly" TextWithImage — explains why the project begins with a GSF Assembly (broad OTel + Green Software community input toward an initial semconv draft) rather than a closed drafting group, with a CTA to `/assemblies/` (reuses the same illustration and framing as the "What is an Assembly" section on `/assemblies/`)
 - "Carbon Has No Shared Vocabulary in OpenTelemetry" TextBlock — the problem statement
-- "What We're Standardizing" — hand-rolled section (not the `CardGrid` component, since it needed an image between the intro text and the cards): heading/body, then the SCI formula diagram (`/assets/tools/sci-for-opentelemetry/sci-formula-diagram.svg`), then a 4-card grid for E/I/M/R using the same markup/classes as `CardGrid`. The diagram is a hand-built SVG (not a photo/screenshot) recreating a GSF formula-explainer graphic in site brand colours — update it by editing the SVG directly if the callout copy changes
+- "What We're Standardizing" — hand-rolled section (not the `CardGrid` component): heading/body, then the SCI formula diagram (`/assets/tools/sci-for-opentelemetry/sci-formula-diagram.svg`). The E/I/M/R card grid that used to sit below the diagram was removed as redundant once the diagram covered the same ground — if this section grows new content later, it doesn't need to be `CardGrid`-shaped again. The diagram is a hand-built SVG (not a photo/screenshot) recreating a GSF formula-explainer graphic in site brand colours — update it by editing the SVG directly if the callout copy changes
 - "Who We're Looking For" CardGrid — the four participant profiles being recruited
 - "Ways to Get Involved" ResourceCards — mirrors the canonical steps from the project's Notion page body (GSF registration → project subscription → Assembly application)
 - CTABanner — links back to the Assembly page to apply, with named contacts (Russ Trow, Jamie Cowan, Sarah Hsu)

--- a/docs/pages/sci-for-opentelemetry.md
+++ b/docs/pages/sci-for-opentelemetry.md
@@ -10,17 +10,29 @@ A short landing page for the SCI for OpenTelemetry project — a new GSF project
 
 ## Dynamic Elements
 
-None. Unlike `carmen.md`, this page does not import from `projects.json` — the project isn't yet in the Notion PWCIs database, so there's no lead/lifecycle data to pull. All content is hardcoded directly in the Astro file.
+### Project data (from Notion)
+
+The project is in the Notion PWCIs database with slug `"sci-otel"` (not `"sci-for-opentelemetry"` — that's just this page's URL). Following the Carmen page's pattern:
+
+- **Parent working group badge** — resolved from `projects.json` to show "A Software Standards Working Group Project" in the hero
+- **Lifecycle stage badge** — read from `projects.json` (currently `"Pre-draft"`), then title-cased per hyphen segment (`"Pre-draft"` → `"Pre-Draft"`) to match the canonical stage names used on `/standards/` (`src/pages/standards/index.astro`) — Notion's casing on this field doesn't always match
+
+If either lookup misses (e.g. `projects.json` hasn't been fetched, or the slug changes in Notion), the badge is simply omitted — there's no hardcoded fallback, matching Carmen's convention once real Notion data exists.
+
+See [Notion doc](../notion.md) for how `projects.json` is populated from the PWCIs database.
 
 ## Static Elements
 
-All content is hardcoded in the page file (in page order):
+Everything else is hardcoded in the page file (in page order):
 
-- Hero — "SCI for OpenTelemetry" heading, "New Project — Recruiting Participants" badge, CTAs to the Assembly application page and the SCI specification
+- Hero — "SCI for OpenTelemetry" heading, subtitle/body copy, CTAs to the Assembly application page and the SCI specification
 - "Carbon Has No Shared Vocabulary in OpenTelemetry" TextBlock — the problem statement
 - "What We're Standardizing" CardGrid — the four SCI formula components (E, I, M, R)
 - "Who We're Looking For" CardGrid — the four participant profiles being recruited
+- "Ways to Get Involved" ResourceCards — mirrors the canonical steps from the project's Notion page body (GSF registration → project subscription → Assembly application)
 - CTABanner — links back to the Assembly page to apply, with named contacts (Russ Trow, Jamie Cowan, Sarah Hsu)
+
+The project's GitHub repo (`Green-Software-Foundation/sci-otel`) is currently private per Notion, so it isn't linked from this page. Once it's made public, add it as a resource card/CTA.
 
 ## Relationship to the Assembly
 
@@ -30,7 +42,8 @@ If the Assembly's slug ever changes in Notion, update the `assemblyUrl` constant
 
 ## How to Update
 
+- **Change lifecycle stage or parent working group** — edit in Notion PWCIs DB (slug `"sci-otel"`), run `npm run fetch-notion`
+- **Add a TeamGrid once named leads exist** — leads are populated from Subscriptions records with role "Project Lead"/"Project Co-Lead" against this PWCI, not from the "Responsible PM" field. Once at least one exists, add a `TeamGrid` fed by `sciOtelProject?.leads`, matching Carmen's pattern
 - **Edit page copy** — modify `src/pages/tools/sci-for-opentelemetry/index.astro` directly
-- **Once the project has leads/lifecycle data in Notion** — add it to the PWCIs database with a matching slug, then follow the Carmen page's pattern (`docs/pages/carmen.md`) to pull `projects.json` data dynamically (lifecycle badge, TeamGrid, parent working group)
 - **Navigation** — the entry in `src/lib/nav-items.ts` (Adoption → Tools section) points to `/tools/sci-for-opentelemetry/`
 - **Assembly status changes** — handled entirely on the Assembly page; no changes needed here unless the slug changes

--- a/docs/pages/sci-for-opentelemetry.md
+++ b/docs/pages/sci-for-opentelemetry.md
@@ -1,0 +1,36 @@
+# SCI for OpenTelemetry Page
+
+Project page for SCI for OpenTelemetry at `/tools/sci-for-opentelemetry/`.
+
+**File:** `src/pages/tools/sci-for-opentelemetry/index.astro`
+
+## What the Page Shows
+
+A short landing page for the SCI for OpenTelemetry project — a new GSF project (convened with Sarah Hsu) developing draft OpenTelemetry semantic conventions for the Software Carbon Intensity (SCI) specification. The project hasn't started yet, so the page is deliberately brief: the problem it addresses, the SCI formula components it will standardise, and who's being recruited to work on it.
+
+## Dynamic Elements
+
+None. Unlike `carmen.md`, this page does not import from `projects.json` — the project isn't yet in the Notion PWCIs database, so there's no lead/lifecycle data to pull. All content is hardcoded directly in the Astro file.
+
+## Static Elements
+
+All content is hardcoded in the page file (in page order):
+
+- Hero — "SCI for OpenTelemetry" heading, "New Project — Recruiting Participants" badge, CTAs to the Assembly application page and the SCI specification
+- "Carbon Has No Shared Vocabulary in OpenTelemetry" TextBlock — the problem statement
+- "What We're Standardizing" CardGrid — the four SCI formula components (E, I, M, R)
+- "Who We're Looking For" CardGrid — the four participant profiles being recruited
+- CTABanner — links back to the Assembly page to apply, with named contacts (Russ Trow, Jamie Cowan, Sarah Hsu)
+
+## Relationship to the Assembly
+
+This project runs its recruitment through an Assembly: `/assemblies/sci-for-open-telemetry/`. Both CTAs on this page ("Apply to Join the Project") link straight to the Assembly detail page rather than duplicating an application form here — the Assembly page owns the actual form, status badge, and deadline logic (see [assemblies doc](./assemblies.md)).
+
+If the Assembly's slug ever changes in Notion, update the `assemblyUrl` constant at the top of `src/pages/tools/sci-for-opentelemetry/index.astro`.
+
+## How to Update
+
+- **Edit page copy** — modify `src/pages/tools/sci-for-opentelemetry/index.astro` directly
+- **Once the project has leads/lifecycle data in Notion** — add it to the PWCIs database with a matching slug, then follow the Carmen page's pattern (`docs/pages/carmen.md`) to pull `projects.json` data dynamically (lifecycle badge, TeamGrid, parent working group)
+- **Navigation** — the entry in `src/lib/nav-items.ts` (Adoption → Tools section) points to `/tools/sci-for-opentelemetry/`
+- **Assembly status changes** — handled entirely on the Assembly page; no changes needed here unless the slug changes

--- a/docs/pages/sci-for-opentelemetry.md
+++ b/docs/pages/sci-for-opentelemetry.md
@@ -25,10 +25,10 @@ See [Notion doc](../notion.md) for how `projects.json` is populated from the PWC
 
 Everything else is hardcoded in the page file (in page order):
 
-- Hero — "SCI for OpenTelemetry" heading, subtitle/body copy, CTAs to the Assembly application page and the SCI specification
+- Hero — heading/body copy written in the same format as `/standards/sci/`'s hero (statement heading + accent phrase + single body paragraph, no separate subtitle), reuses the SCI page's illustration (`/assets/standards/sci/hero-illustration.svg`), CTAs to the Assembly application page and the SCI specification
 - "Starting with an Assembly" TextWithImage — explains why the project begins with a GSF Assembly (broad OTel + Green Software community input toward an initial semconv draft) rather than a closed drafting group, with a CTA to `/assemblies/` (reuses the same illustration and framing as the "What is an Assembly" section on `/assemblies/`)
 - "Carbon Has No Shared Vocabulary in OpenTelemetry" TextBlock — the problem statement
-- "What We're Standardizing" CardGrid — the four SCI formula components (E, I, M, R)
+- "What We're Standardizing" — hand-rolled section (not the `CardGrid` component, since it needed an image between the intro text and the cards): heading/body, then the SCI formula diagram (`/assets/tools/sci-for-opentelemetry/sci-formula-diagram.svg`), then a 4-card grid for E/I/M/R using the same markup/classes as `CardGrid`. The diagram is a hand-built SVG (not a photo/screenshot) recreating a GSF formula-explainer graphic in site brand colours — update it by editing the SVG directly if the callout copy changes
 - "Who We're Looking For" CardGrid — the four participant profiles being recruited
 - "Ways to Get Involved" ResourceCards — mirrors the canonical steps from the project's Notion page body (GSF registration → project subscription → Assembly application)
 - CTABanner — links back to the Assembly page to apply, with named contacts (Russ Trow, Jamie Cowan, Sarah Hsu)

--- a/docs/pages/sci-for-opentelemetry.md
+++ b/docs/pages/sci-for-opentelemetry.md
@@ -26,6 +26,7 @@ See [Notion doc](../notion.md) for how `projects.json` is populated from the PWC
 Everything else is hardcoded in the page file (in page order):
 
 - Hero — "SCI for OpenTelemetry" heading, subtitle/body copy, CTAs to the Assembly application page and the SCI specification
+- "Starting with an Assembly" TextWithImage — explains why the project begins with a GSF Assembly (broad OTel + Green Software community input toward an initial semconv draft) rather than a closed drafting group, with a CTA to `/assemblies/` (reuses the same illustration and framing as the "What is an Assembly" section on `/assemblies/`)
 - "Carbon Has No Shared Vocabulary in OpenTelemetry" TextBlock — the problem statement
 - "What We're Standardizing" CardGrid — the four SCI formula components (E, I, M, R)
 - "Who We're Looking For" CardGrid — the four participant profiles being recruited

--- a/public/assets/tools/sci-for-opentelemetry/sci-formula-diagram.svg
+++ b/public/assets/tools/sci-for-opentelemetry/sci-formula-diagram.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" role="img" aria-labelledby="sci-formula-title">
+  <title id="sci-formula-title">SCI = ((E * I) + M) per R — E is energy consumed by software in kWh, I is carbon emitted per kWh of energy, M is carbon emitted through the hardware the software runs on, R is the functional unit describing how software scales</title>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f5952"/>
+      <stop offset="100%" stop-color="#04302c"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1920" height="1080" fill="url(#bg)"/>
+
+  <g fill="none" stroke="#aecc53" stroke-width="4" stroke-linecap="round">
+    <!-- I callout (top-left) -->
+    <rect x="250" y="190" width="620" height="185" rx="92.5"/>
+    <path d="M 700 375 Q 720 420 795 460 Q 800 500 800 540" stroke-linejoin="round"/>
+
+    <!-- M callout (top-right) -->
+    <rect x="965" y="160" width="655" height="230" rx="115"/>
+    <path d="M 1120 390 Q 1105 425 1090 460 Q 1090 500 1090 540" stroke-linejoin="round"/>
+
+    <!-- E callout (bottom-left) -->
+    <rect x="245" y="690" width="590" height="180" rx="90"/>
+    <path d="M 610 690 Q 650 650 705 620 Q 705 605 705 590" stroke-linejoin="round"/>
+
+    <!-- R callout (bottom-right) -->
+    <rect x="1085" y="690" width="705" height="200" rx="100"/>
+    <path d="M 1480 690 Q 1495 650 1500 620 Q 1500 605 1500 590" stroke-linejoin="round"/>
+  </g>
+
+  <g font-family="'Nunito Sans', Arial, sans-serif" font-weight="700" fill="#aecc53" text-anchor="middle">
+    <text x="560" y="270" font-size="46">Carbon emitted per kWh</text>
+    <text x="560" y="330" font-size="46">of energy, gCO2/kWh</text>
+
+    <text x="1292" y="228" font-size="46">Carbon emitted through</text>
+    <text x="1292" y="288" font-size="46">the hardware that the</text>
+    <text x="1292" y="348" font-size="46">software is running on</text>
+
+    <text x="540" y="765" font-size="46">Energy consumed by</text>
+    <text x="540" y="825" font-size="46">software in kWh</text>
+
+    <text x="1437" y="745" font-size="46">Functional Unit; this is how</text>
+    <text x="1437" y="805" font-size="46">software scales, for example</text>
+    <text x="1437" y="865" font-size="46">per user or per device</text>
+  </g>
+
+  <text x="960" y="595" font-family="'Nunito Sans', Arial, sans-serif" font-weight="800" font-size="105" fill="#ffffff" text-anchor="middle">SCI = ((E * I) + M) per R</text>
+</svg>

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -179,6 +179,12 @@ export const navItems = [
             description: "Measure the carbon footprint of your software",
             /* iconSrc: pi("if"), icon: "workflow", */ external: true,
           },
+          {
+            href: "/tools/sci-for-opentelemetry/",
+            label: "SCI for OpenTelemetry",
+            description: "Draft OpenTelemetry semantic conventions for SCI",
+            /* iconSrc: pi("sci-for-opentelemetry"), icon: "activity", */
+          },
         ],
       },
     ],

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -182,7 +182,7 @@ export const navItems = [
           {
             href: "/tools/sci-for-opentelemetry/",
             label: "SCI for OpenTelemetry",
-            description: "Draft OpenTelemetry semantic conventions for SCI",
+            description: "Semantic conventions and instrumentation for SCI in OpenTelemetry",
             /* iconSrc: pi("sci-for-opentelemetry"), icon: "activity", */
           },
         ],

--- a/src/pages/tools/sci-for-opentelemetry/index.astro
+++ b/src/pages/tools/sci-for-opentelemetry/index.astro
@@ -29,7 +29,7 @@ const lifecycleLabel = sciOtelProject?.lifecycle
 
 <Layout
   title="SCI for OpenTelemetry | Green Software Foundation"
-  description="A new GSF project developing draft OpenTelemetry semantic conventions for the Software Carbon Intensity (SCI) specification. Applications to join are open now."
+  description="A new GSF project bringing Software Carbon Intensity (SCI) to OpenTelemetry — starting with draft semantic conventions, then building the instrumentation to put them into practice. Applications to join are open now."
 >
   <Navbar
     logoSrc="/assets/gsf-logo-full.svg"
@@ -53,7 +53,7 @@ const lifecycleLabel = sciOtelProject?.lifecycle
     ]}
     heading="Speak the Same Carbon Language:"
     headingAccent="SCI for OpenTelemetry"
-    body="Software Carbon Intensity (SCI) measurements have no shared semantic conventions in OpenTelemetry today. This project is developing a draft set of conventions covering energy consumption, carbon intensity, embodied carbon, and the functional unit — so every observability stack can emit and consume carbon data consistently."
+    body="Software Carbon Intensity (SCI) measurements have no shared semantic conventions in OpenTelemetry today. This project starts by drafting conventions covering energy consumption, carbon intensity, embodied carbon, and the functional unit, then builds the instrumentation that puts them into practice — so every observability stack can emit and consume carbon data consistently."
     ctas={[
       { text: "Apply to Join the Project", variant: "primary", href: assemblyUrl },
       { text: "Read the SCI Specification", variant: "outline", href: "https://sci.greensoftware.foundation/" },
@@ -83,7 +83,7 @@ const lifecycleLabel = sciOtelProject?.lifecycle
     heading="Carbon Has No *Shared Vocabulary* in OpenTelemetry"
     body="The Software Carbon Intensity (SCI) specification (ISO/IEC 21031:2022) defines a standardised method for measuring the carbon intensity of a software system. Its components — energy consumption, hardware utilisation, and a functional unit — map directly onto concepts that observability practitioners already instrument. But OpenTelemetry has no agreed attribute names or metric definitions for any of them."
     bodyExtra={[
-      "A previous attempt to address this stalled in 2023 when the primary driver changed roles. This project picks that work back up, with the goal of bringing a draft set of conventions to the OpenTelemetry Semantic Conventions SIG for review.",
+      "A previous attempt to address this stalled in 2023 when the primary driver changed roles. This project picks that work back up: starting with a draft set of semantic conventions for the OpenTelemetry Semantic Conventions SIG to review, then building the instrumentation that puts them into practice.",
     ]}
     bgClass="bg-accent-lightest-2"
   />
@@ -99,26 +99,12 @@ const lifecycleLabel = sciOtelProject?.lifecycle
           SCI = ((E × I) + M) per R — a draft baseline set of semantic conventions covering each component of the formula, plus the composite score itself
         </p>
       </div>
-      <div class="mx-auto mb-10 max-w-4xl overflow-hidden rounded-2xl md:mb-12">
+      <div class="mx-auto max-w-4xl overflow-hidden rounded-2xl">
         <img
           src="/assets/tools/sci-for-opentelemetry/sci-formula-diagram.svg"
           alt="The SCI formula, SCI equals E times I plus M per R, where E is energy consumed by software in kWh, I is carbon emitted per kWh of energy in gCO2 per kWh, M is carbon emitted through the hardware the software runs on, and R is the functional unit describing how software scales, for example per user or per device"
           class="w-full"
         />
-      </div>
-      <div class="relative z-10 grid gap-4 lg:gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        {[
-          { title: "Operational Energy (E)", description: "Energy consumed by the software system while it runs." },
-          { title: "Carbon Intensity (I)", description: "Carbon intensity of the electricity that energy is drawn from." },
-          { title: "Embodied Carbon (M)", description: "Embodied carbon of the hardware the software runs on." },
-          { title: "Functional Unit (R)", description: "The unit of work the score is normalised against." },
-        ].map((card) => (
-          <div class="flex flex-col rounded-xl border bg-white p-6 shadow-sm">
-            <hr class="mb-4 border-border" />
-            <h3 class="text-lg font-bold">{card.title}</h3>
-            <p class="mt-2 text-sm text-gray-darker">{card.description}</p>
-          </div>
-        ))}
       </div>
     </div>
   </section>

--- a/src/pages/tools/sci-for-opentelemetry/index.astro
+++ b/src/pages/tools/sci-for-opentelemetry/index.astro
@@ -7,10 +7,23 @@ import Breadcrumb from "@/components/breadcrumb.astro";
 import Hero from "@/components/hero.astro";
 import TextBlock from "@/components/text-block.astro";
 import CardGrid from "@/components/card-grid.astro";
+import ResourceCards from "@/components/resource-cards.astro";
 import CTABanner from "@/components/cta-banner.astro";
 import Footer from "@/components/footer.astro";
 
+import projects from "@/data/projects.json";
+
 const assemblyUrl = "/assemblies/sci-for-open-telemetry/";
+
+const sciOtelProject = projects.find((p: any) => p.slug === "sci-otel");
+const parentWg = projects.find((p: any) => p.name === sciOtelProject?.parent);
+
+// Notion's lifecycle stage casing doesn't always match the canonical stage
+// names used on /standards/ (e.g. "Pre-draft" vs "Pre-Draft") — normalise for display.
+const lifecycleLabel = sciOtelProject?.lifecycle
+  ?.split("-")
+  .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
+  .join("-");
 ---
 
 <Layout
@@ -33,7 +46,10 @@ const assemblyUrl = "/assemblies/sci-for-open-telemetry/";
 
   <!-- Hero -->
   <Hero
-    badges={[{ text: "New Project — Recruiting Participants", variant: "dark" }]}
+    badges={[
+      ...(parentWg ? [{ text: `A ${parentWg.name} Project` }] : []),
+      ...(lifecycleLabel ? [{ text: lifecycleLabel, variant: "dark" as const }] : []),
+    ]}
     heading="SCI for"
     headingAccent="OpenTelemetry"
     subtitle="Bringing Software Carbon Intensity into OpenTelemetry's semantic conventions, so carbon becomes a signal every observability stack can emit and consume consistently."
@@ -113,9 +129,35 @@ const assemblyUrl = "/assemblies/sci-for-open-telemetry/";
   />
 
   <!-- Get Involved -->
+  <ResourceCards
+    heading="Ways to *Get Involved*"
+    columns={3}
+    cards={[
+      {
+        title: "Register with GSF",
+        description: "Complete GSF registration — required before you can subscribe to any project.",
+        ctaText: "Register",
+        ctaHref: "https://wiki.greensoftware.foundation/register",
+      },
+      {
+        title: "Subscribe to the Project",
+        description: "Join the mailing list and meetings for Software Carbon Intensity for OpenTelemetry.",
+        ctaText: "Subscribe",
+        ctaHref: "https://wiki.greensoftware.foundation/subscribe",
+      },
+      {
+        title: "Apply to the Assembly",
+        description: "The project's initial development work runs through an Assembly — apply to take part.",
+        ctaText: "Apply Now",
+        ctaHref: assemblyUrl,
+      },
+    ]}
+    bgClass="bg-accent-lightest-2"
+  />
+
   <CTABanner
     heading="Help Make Carbon a First-Class Signal"
-    body="Applications to join the SCI for OpenTelemetry project are open now. If you'd like to get involved or have questions, reach out to Russ Trow (russell@greensoftware.foundation), Jamie Cowan (jamie@greensoftware.foundation), or Sarah Hsu (@greenhsu123)."
+    body="If you'd like to get involved or have questions, reach out to Russ Trow (russell@greensoftware.foundation), Jamie Cowan (jamie@greensoftware.foundation), or Sarah Hsu (@greenhsu123)."
     ctaText="Apply to Join the Project"
     ctaHref={assemblyUrl}
   />

--- a/src/pages/tools/sci-for-opentelemetry/index.astro
+++ b/src/pages/tools/sci-for-opentelemetry/index.astro
@@ -1,0 +1,124 @@
+---
+import Layout from "@/layouts/showcase.astro";
+import { navItems } from "@/lib/nav-items";
+
+import Navbar from "@/components/navbar.astro";
+import Breadcrumb from "@/components/breadcrumb.astro";
+import Hero from "@/components/hero.astro";
+import TextBlock from "@/components/text-block.astro";
+import CardGrid from "@/components/card-grid.astro";
+import CTABanner from "@/components/cta-banner.astro";
+import Footer from "@/components/footer.astro";
+
+const assemblyUrl = "/assemblies/sci-for-open-telemetry/";
+---
+
+<Layout
+  title="SCI for OpenTelemetry | Green Software Foundation"
+  description="A new GSF project developing draft OpenTelemetry semantic conventions for the Software Carbon Intensity (SCI) specification. Applications to join are open now."
+>
+  <Navbar
+    logoSrc="/assets/gsf-logo-full.svg"
+    logoAlt="Green Software Foundation"
+    logoHref="/"
+    topBar="none"
+    showSearch
+    navItems={navItems}
+  />
+
+  <Breadcrumb items={[
+    { label: "Home", href: "/" },
+    { label: "SCI for OpenTelemetry" },
+  ]} />
+
+  <!-- Hero -->
+  <Hero
+    badges={[{ text: "New Project — Recruiting Participants", variant: "dark" }]}
+    heading="SCI for"
+    headingAccent="OpenTelemetry"
+    subtitle="Bringing Software Carbon Intensity into OpenTelemetry's semantic conventions, so carbon becomes a signal every observability stack can emit and consume consistently."
+    body="There are currently no shared semantic conventions for representing SCI-related measurements in OpenTelemetry. Without them, teams measuring software carbon intensity use inconsistent attribute names and metric definitions, and tools like Kepler can't be composed into a coherent pipeline without bespoke integration work. The GSF, in collaboration with Sarah Hsu, is convening a new project to fix that."
+    ctas={[
+      { text: "Apply to Join the Project", variant: "primary", href: assemblyUrl },
+      { text: "Read the SCI Specification", variant: "outline", href: "https://sci.greensoftware.foundation/" },
+    ]}
+    imageSrc="/assets/hero-illustration.svg"
+    imageAlt="SCI for OpenTelemetry"
+    bgClass="bg-accent-lightest-2"
+    id="overview"
+  />
+
+  <!-- The Problem -->
+  <TextBlock
+    heading="Carbon Has No *Shared Vocabulary* in OpenTelemetry"
+    body="The Software Carbon Intensity (SCI) specification (ISO/IEC 21031:2022) defines a standardised method for measuring the carbon intensity of a software system. Its components — energy consumption, hardware utilisation, and a functional unit — map directly onto concepts that observability practitioners already instrument. But OpenTelemetry has no agreed attribute names or metric definitions for any of them."
+    bodyExtra={[
+      "A previous attempt to address this stalled in 2023 when the primary driver changed roles. This project picks that work back up, with the goal of bringing a draft set of conventions to the OpenTelemetry Semantic Conventions SIG for review.",
+    ]}
+    bgClass="bg-white"
+  />
+
+  <!-- What We're Standardizing -->
+  <CardGrid
+    heading="What We're *Standardizing*"
+    body="SCI = ((E × I) + M) per R — a draft baseline set of semantic conventions covering each component of the formula, plus the composite score itself"
+    columns={4}
+    align="center"
+    cards={[
+      {
+        title: "Operational Energy (E)",
+        description: "Energy consumed by the software system while it runs.",
+      },
+      {
+        title: "Carbon Intensity (I)",
+        description: "Carbon intensity of the electricity that energy is drawn from.",
+      },
+      {
+        title: "Embodied Carbon (M)",
+        description: "Embodied carbon of the hardware the software runs on.",
+      },
+      {
+        title: "Functional Unit (R)",
+        description: "The unit of work the score is normalised against.",
+      },
+    ]}
+    bgClass="bg-accent-lightest-2"
+  />
+
+  <!-- Who We're Looking For -->
+  <CardGrid
+    heading="Who We're *Looking For*"
+    body="Applications are open to anyone with relevant expertise, or who knows someone who has it"
+    columns={4}
+    align="center"
+    cards={[
+      {
+        title: "Semantic Conventions Experience",
+        description: "OpenTelemetry semantic conventions experience, to ensure the output maps cleanly into OTel from the start.",
+      },
+      {
+        title: "Carbon Measurement Expertise",
+        description: "Green software / carbon measurement expertise: SCI, Kepler, carbon intensity data sources.",
+      },
+      {
+        title: "Instrumentation Experience",
+        description: "Instrumentation experience, to inform how conventions would be implemented in practice.",
+      },
+      {
+        title: "Observability Backend Vendors",
+        description: "Interest from observability backend vendors, to ensure standardised carbon signals are consumable across the ecosystem.",
+      },
+    ]}
+    bgClass="bg-white"
+  />
+
+  <!-- Get Involved -->
+  <CTABanner
+    heading="Help Make Carbon a First-Class Signal"
+    body="Applications to join the SCI for OpenTelemetry project are open now. If you'd like to get involved or have questions, reach out to Russ Trow (russell@greensoftware.foundation), Jamie Cowan (jamie@greensoftware.foundation), or Sarah Hsu (@greenhsu123)."
+    ctaText="Apply to Join the Project"
+    ctaHref={assemblyUrl}
+  />
+
+  <Footer />
+</Layout>

--- a/src/pages/tools/sci-for-opentelemetry/index.astro
+++ b/src/pages/tools/sci-for-opentelemetry/index.astro
@@ -51,15 +51,14 @@ const lifecycleLabel = sciOtelProject?.lifecycle
       ...(parentWg ? [{ text: `A ${parentWg.name} Project` }] : []),
       ...(lifecycleLabel ? [{ text: lifecycleLabel, variant: "dark" as const }] : []),
     ]}
-    heading="SCI for"
-    headingAccent="OpenTelemetry"
-    subtitle="Bringing Software Carbon Intensity into OpenTelemetry's semantic conventions, so carbon becomes a signal every observability stack can emit and consume consistently."
-    body="There are currently no shared semantic conventions for representing SCI-related measurements in OpenTelemetry. Without them, teams measuring software carbon intensity use inconsistent attribute names and metric definitions, and tools like Kepler can't be composed into a coherent pipeline without bespoke integration work. The GSF, in collaboration with Sarah Hsu, is convening a new project to fix that."
+    heading="Speak the Same Carbon Language:"
+    headingAccent="SCI for OpenTelemetry"
+    body="Software Carbon Intensity (SCI) measurements have no shared semantic conventions in OpenTelemetry today. This project is developing a draft set of conventions covering energy consumption, carbon intensity, embodied carbon, and the functional unit — so every observability stack can emit and consume carbon data consistently."
     ctas={[
       { text: "Apply to Join the Project", variant: "primary", href: assemblyUrl },
       { text: "Read the SCI Specification", variant: "outline", href: "https://sci.greensoftware.foundation/" },
     ]}
-    imageSrc="/assets/hero-illustration.svg"
+    imageSrc="/assets/standards/sci/hero-illustration.svg"
     imageAlt="SCI for OpenTelemetry"
     bgClass="bg-accent-lightest-2"
     id="overview"
@@ -90,31 +89,39 @@ const lifecycleLabel = sciOtelProject?.lifecycle
   />
 
   <!-- What We're Standardizing -->
-  <CardGrid
-    heading="What We're *Standardizing*"
-    body="SCI = ((E × I) + M) per R — a draft baseline set of semantic conventions covering each component of the formula, plus the composite score itself"
-    columns={4}
-    align="center"
-    cards={[
-      {
-        title: "Operational Energy (E)",
-        description: "Energy consumed by the software system while it runs.",
-      },
-      {
-        title: "Carbon Intensity (I)",
-        description: "Carbon intensity of the electricity that energy is drawn from.",
-      },
-      {
-        title: "Embodied Carbon (M)",
-        description: "Embodied carbon of the hardware the software runs on.",
-      },
-      {
-        title: "Functional Unit (R)",
-        description: "The unit of work the score is normalised against.",
-      },
-    ]}
-    bgClass="bg-white"
-  />
+  <section class="py-12 md:py-16 lg:py-20 bg-white">
+    <div class="relative container">
+      <div class="mb-8 md:mb-10 text-center">
+        <h2 class="text-2xl font-semibold md:text-3xl lg:text-4xl">
+          What We're <span class="font-bold text-primary">Standardizing</span>
+        </h2>
+        <p class="mx-auto mt-4 max-w-2xl text-base text-primary-dark">
+          SCI = ((E × I) + M) per R — a draft baseline set of semantic conventions covering each component of the formula, plus the composite score itself
+        </p>
+      </div>
+      <div class="mx-auto mb-10 max-w-4xl overflow-hidden rounded-2xl md:mb-12">
+        <img
+          src="/assets/tools/sci-for-opentelemetry/sci-formula-diagram.svg"
+          alt="The SCI formula, SCI equals E times I plus M per R, where E is energy consumed by software in kWh, I is carbon emitted per kWh of energy in gCO2 per kWh, M is carbon emitted through the hardware the software runs on, and R is the functional unit describing how software scales, for example per user or per device"
+          class="w-full"
+        />
+      </div>
+      <div class="relative z-10 grid gap-4 lg:gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {[
+          { title: "Operational Energy (E)", description: "Energy consumed by the software system while it runs." },
+          { title: "Carbon Intensity (I)", description: "Carbon intensity of the electricity that energy is drawn from." },
+          { title: "Embodied Carbon (M)", description: "Embodied carbon of the hardware the software runs on." },
+          { title: "Functional Unit (R)", description: "The unit of work the score is normalised against." },
+        ].map((card) => (
+          <div class="flex flex-col rounded-xl border bg-white p-6 shadow-sm">
+            <hr class="mb-4 border-border" />
+            <h3 class="text-lg font-bold">{card.title}</h3>
+            <p class="mt-2 text-sm text-gray-darker">{card.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
 
   <!-- Who We're Looking For -->
   <CardGrid

--- a/src/pages/tools/sci-for-opentelemetry/index.astro
+++ b/src/pages/tools/sci-for-opentelemetry/index.astro
@@ -5,6 +5,7 @@ import { navItems } from "@/lib/nav-items";
 import Navbar from "@/components/navbar.astro";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import Hero from "@/components/hero.astro";
+import TextWithImage from "@/components/text-with-image.astro";
 import TextBlock from "@/components/text-block.astro";
 import CardGrid from "@/components/card-grid.astro";
 import ResourceCards from "@/components/resource-cards.astro";
@@ -64,6 +65,20 @@ const lifecycleLabel = sciOtelProject?.lifecycle
     id="overview"
   />
 
+  <!-- Starting with an Assembly -->
+  <TextWithImage
+    badge="HOW THIS PROJECT WORKS"
+    heading="Starting with an"
+    headingAccent="Assembly"
+    headingStyle="light"
+    body="Rather than a small group drafting semantic conventions on its own, this project begins with a GSF Assembly — a structured, time-boxed process for bringing a group of experts to consensus on a hard question. The SCI for OpenTelemetry Assembly is how the OpenTelemetry and Green Software communities work through the SCI formula together and arrive at an initial draft of the semantic conventions, before it goes to the OpenTelemetry Semantic Conventions SIG for review."
+    imageSrc="/assets/assemblies-process-illustration.webp"
+    imageAlt="The Assembly process illustration"
+    ctaText="How Assemblies Work"
+    ctaHref="/assemblies/"
+    bgClass="bg-white"
+  />
+
   <!-- The Problem -->
   <TextBlock
     heading="Carbon Has No *Shared Vocabulary* in OpenTelemetry"
@@ -71,7 +86,7 @@ const lifecycleLabel = sciOtelProject?.lifecycle
     bodyExtra={[
       "A previous attempt to address this stalled in 2023 when the primary driver changed roles. This project picks that work back up, with the goal of bringing a draft set of conventions to the OpenTelemetry Semantic Conventions SIG for review.",
     ]}
-    bgClass="bg-white"
+    bgClass="bg-accent-lightest-2"
   />
 
   <!-- What We're Standardizing -->
@@ -98,7 +113,7 @@ const lifecycleLabel = sciOtelProject?.lifecycle
         description: "The unit of work the score is normalised against.",
       },
     ]}
-    bgClass="bg-accent-lightest-2"
+    bgClass="bg-white"
   />
 
   <!-- Who We're Looking For -->
@@ -125,7 +140,7 @@ const lifecycleLabel = sciOtelProject?.lifecycle
         description: "Interest from observability backend vendors, to ensure standardised carbon signals are consumable across the ecosystem.",
       },
     ]}
-    bgClass="bg-white"
+    bgClass="bg-accent-lightest-2"
   />
 
   <!-- Get Involved -->
@@ -152,7 +167,7 @@ const lifecycleLabel = sciOtelProject?.lifecycle
         ctaHref: assemblyUrl,
       },
     ]}
-    bgClass="bg-accent-lightest-2"
+    bgClass="bg-white"
   />
 
   <CTABanner


### PR DESCRIPTION
## Summary

Adds a new project landing page for "SCI for OpenTelemetry" at `/tools/sci-for-opentelemetry/`, a new GSF initiative developing draft OpenTelemetry semantic conventions for the Software Carbon Intensity (SCI) specification. The page is designed to recruit participants and explain the project's scope.

## Changes

- **New page:** `src/pages/tools/sci-for-opentelemetry/index.astro` — landing page with hero, problem statement, SCI formula components breakdown, participant recruitment profiles, and CTA banner linking to the Assembly application
- **Navigation:** Added "SCI for OpenTelemetry" entry to the Adoption → Tools section in `src/lib/nav-items.ts`
- **Documentation:** Added `docs/pages/sci-for-opentelemetry.md` explaining page structure, content sources, and relationship to the Assembly recruitment flow

## Implementation Details

- All content is hardcoded in the page file (not pulled from Notion) since the project is not yet in the PWCIs database
- Both CTAs link to `/assemblies/sci-for-open-telemetry/` where the actual application form and recruitment status are managed
- Uses existing layout components (Hero, TextBlock, CardGrid, CTABanner) following established patterns
- Includes documentation for future migration to dynamic data once the project is added to Notion

https://claude.ai/code/session_01Q9ZifUjgt4WzJRe8mRfcT6