### PR TITLE
Tweak SILO mission card wording

### DIFF
--- a/src/pages/standards/silo/index.astro
+++ b/src/pages/standards/silo/index.astro
@@ -187,9 +187,9 @@ const MEMBERSHIP_CTA = "/membership/";
           <img src="/assets/standards/wdpc/mission-card-up-decor.svg" class="h-12 w-16 md:h-14 md:w-24" />
         </div>
         <div class="text-center">
-          <h3 class="text-2xl font-semibold">Complementing, Not Replacing, WDPC</h3>
+          <h3 class="text-2xl font-semibold">Complementing, WDPC</h3>
           <p class="mt-3 text-lg font-medium text-primary-dark italic md:mt-4 md:text-xl">
-            Rather than replacing existing management protocols or telemetry systems, SILO plugs into the existing WDPC Data Bus and defines a common semantic layer — providing semantic models, APIs, governance, and interoperability as a foundation for future interoperability across the data centre ecosystem.
+            SILO complete the existing management protocols or telemetry systems, plugs into the existing WDPC Data Bus and defines a common semantic layer — providing semantic models, APIs, governance, and interoperability as a foundation for future interoperability across the data centre ecosystem.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Follow-up to #85 (merged) — updates the "Complementing, WDPC" mission card copy on the SILO standards page (`src/pages/standards/silo/index.astro`) per requested wording changes:
  - Heading: "Complementing, Not Replacing, WDPC" → "Complementing, WDPC"
  - Body: "Rather than replacing existing management protocols or telemetry systems, SILO plugs into..." → "SILO complete the existing management protocols or telemetry systems, plugs into..."

## Test plan

- [x] Confirmed the diff against `main` only touches this one section's copy


---
_Generated by [Claude Code](https://claude.ai/code/session_01VoKLn1YB3RtALXRjzt87Gd)_