### PR TITLE
Update Get Involved sections on Software standards pages

### DIFF
--- a/src/pages/standards/sci-ai/index.astro
+++ b/src/pages/standards/sci-ai/index.astro
@@ -353,7 +353,7 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
   <!-- Get Involved -->
   <CardGrid
     heading="Get Involved"
-    body="Your expertise and experience can help refine this transformative standard"
+    body="The Software Standards Working Group meets every Thursday at 15:00 UTC. We welcome all GSF members to join the call, share their perspectives, and help shape our standards together."
     columns={4}
     align="left"
     decorSrc="/assets/standards/sci-ai/shape-decor.svg"
@@ -386,6 +386,13 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
         description: "Reach out directly to the GSF team",
         ctaText: "Get in touch",
         ctaHref: "https://greensoftware.foundation/join-us",
+      },
+      {
+        icon: "/assets/standards/sci/resource-guide-icon.svg",
+        title: "Explore Related Standards",
+        description: "See all the Software standards developed by the Working Group, including SCI, SCI for AI, SEI, and SWI",
+        ctaText: "View all Software standards",
+        ctaHref: "/standards/",
       },
     ]}
     bgClass="bg-accent-lightest-2"

--- a/src/pages/standards/sci/index.astro
+++ b/src/pages/standards/sci/index.astro
@@ -386,7 +386,7 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
   <!-- Get Involved -->
   <CardGrid
     heading="Get Involved"
-    body="Help Shape the Future of Software Carbon Measurement"
+    body="The Software Standards Working Group meets every Thursday at 15:00 UTC. We welcome all GSF members to join the call, share their perspectives, and help shape our standards together."
     columns={4}
     cards={[
       {
@@ -417,6 +417,13 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
         description: "Join the foundation to participate in standards development",
         ctaText: "Get in touch",
         ctaHref: "/membership/",
+      },
+      {
+        icon: "/assets/standards/sci/resource-guide-icon.svg",
+        title: "Explore Related Standards",
+        description: "See all the Software standards developed by the Working Group, including SCI, SCI for AI, SEI, and SWI",
+        ctaText: "View all Software standards",
+        ctaHref: "/standards/",
       },
     ]}
     bgClass="bg-accent-lightest-2"
@@ -451,7 +458,7 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
   <!-- Get Involved -->
   <CardGrid
     heading="Get Involved"
-    body="Help Shape the Future of Software Carbon Measurement"
+    body="The Software Standards Working Group meets every Thursday at 15:00 UTC. We welcome all GSF members to join the call, share their perspectives, and help shape our standards together."
     columns={4}
     cards={[
       {
@@ -482,6 +489,13 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
         description: "Join the foundation to participate in standards development",
         ctaText: "Get in touch",
         ctaHref: "/membership/",
+      },
+      {
+        icon: "/assets/standards/sci/resource-guide-icon.svg",
+        title: "Explore Related Standards",
+        description: "See all the Software standards developed by the Working Group, including SCI, SCI for AI, SEI, and SWI",
+        ctaText: "View all Software standards",
+        ctaHref: "/standards/",
       },
     ]}
     bgClass="bg-accent-lightest-2"

--- a/src/pages/standards/sei/index.astro
+++ b/src/pages/standards/sei/index.astro
@@ -223,8 +223,8 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
   <!-- Get Involved -->
   <CardGrid
     heading="Get Involved"
-    body="Help Shape Software Energy Intensity"
-    columns={3}
+    body="The Software Standards Working Group meets every Thursday at 15:00 UTC. We welcome all GSF members to join the call, share their perspectives, and help shape our standards together."
+    columns={4}
     cards={[
       {
         icon: "/assets/standards/sci/resource-spec-icon.svg",
@@ -247,6 +247,13 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
         description: "Join the foundation to participate in standards development",
         ctaText: "Get in touch",
         ctaHref: "https://greensoftware.foundation/membership",
+      },
+      {
+        icon: "/assets/standards/sci/resource-guide-icon.svg",
+        title: "Explore Related Standards",
+        description: "See all the Software standards developed by the Working Group, including SCI, SCI for AI, SEI, and SWI",
+        ctaText: "View all Software standards",
+        ctaHref: "/standards/",
       },
     ]}
     bgClass="bg-accent-lightest-2"

--- a/src/pages/standards/swi/index.astro
+++ b/src/pages/standards/swi/index.astro
@@ -195,8 +195,8 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
   <!-- Get Involved -->
   <CardGrid
     heading="Get Involved"
-    body="Help Shape Software Water Intensity"
-    columns={3}
+    body="The Software Standards Working Group meets every Thursday at 15:00 UTC. We welcome all GSF members to join the call, share their perspectives, and help shape our standards together."
+    columns={4}
     cards={[
       {
         icon: "/assets/standards/sci/resource-discuss-icon.svg",
@@ -207,18 +207,18 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
         featured: true,
       },
       {
-        icon: "/assets/standards/sci/resource-spec-icon.svg",
-        title: "Learn About Our Standards",
-        description: "Explore how the Green Software Foundation develops open, rigorous specifications",
-        ctaText: "View standards",
-        ctaHref: "/standards/",
-      },
-      {
         icon: "/assets/standards/soft/join-gsf-icon.svg",
         title: "Become a GSF Member",
         description: "Join the foundation to participate in standards development",
         ctaText: "Get in touch",
         ctaHref: "/membership/",
+      },
+      {
+        icon: "/assets/standards/sci/resource-guide-icon.svg",
+        title: "Explore Related Standards",
+        description: "See all the Software standards developed by the Working Group, including SCI, SCI for AI, SEI, and SWI",
+        ctaText: "View all Software standards",
+        ctaHref: "/standards/",
       },
     ]}
     bgClass="bg-accent-lightest-2"


### PR DESCRIPTION
## Summary
- Add the Software Standards Working Group meeting schedule (Thursdays at 15:00 UTC) to the "Get Involved" section body text on the SCI, SCI for AI, SEI, and SWI standards pages
- Add a new "Explore Related Standards" card to each page's "Get Involved" grid, linking to `/standards/` and referencing the other Software standards (SCI, SCI for AI, SEI, SWI)
- On the SWI page, removed the "Learn About Our Standards" card since it pointed to the same `/standards/` URL as the new card (avoids a duplicate CTA)
- Note: the SCI page has two "Get Involved" sections further down the page (pre-existing duplication, not introduced by this PR) — both were updated identically

## Test plan
- [ ] Visually verify the "Get Involved" section renders correctly on `/standards/sci/`, `/standards/sci-ai/`, `/standards/sei/`, and `/standards/swi/`
- [ ] Confirm the new "Explore Related Standards" card links to `/standards/`


---
_Generated by [Claude Code](https://claude.ai/code/session_01JjBY2nvPkEUCfNN88XJW3J)_