### PR TITLE
Fix SEI project slug mismatch so it appears in Current Standards & Projects

### DIFF
--- a/src/pages/standards/index.astro
+++ b/src/pages/standards/index.astro
@@ -38,7 +38,7 @@ const standardDefs = [
   { slug: "silo" },
   { slug: "wdpc" },
   { slug: "open19" },
-  { slug: "see", urlSlug: "sei" },
+  { slug: "sei" },
   { slug: "swe" },
 ];
 const standardProjects = standardDefs

--- a/src/pages/standards/sei/index.astro
+++ b/src/pages/standards/sei/index.astro
@@ -18,11 +18,11 @@ import ArticleCarousel from "@/components/article-carousel.astro";
 import projects from "@/data/projects.json";
 import { getCollection } from "astro:content";
 import { articleUrl } from "@/lib/utils";
-const seeProject = projects.find(p => p.slug === "see");
-const parentWg = projects.find(p => p.name === seeProject?.parent);
+const seiProject = projects.find(p => p.slug === "sei");
+const parentWg = projects.find(p => p.name === seiProject?.parent);
 
 const carouselArticles = (await getCollection("articles", (a) => a.data.published !== false))
-  .filter(a => (a.data.tags || []).map((t: string) => t.toLowerCase()).includes("see"))
+  .filter(a => (a.data.tags || []).map((t: string) => t.toLowerCase()).includes("sei"))
   .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
   .map(a => ({
     title: a.data.title,
@@ -56,7 +56,7 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
   <Hero
     badges={[
       ...(parentWg ? [{ text: `A ${parentWg.name} Project` }] : []),
-      ...(seeProject?.lifecycle ? [{ text: seeProject.lifecycle, variant: "dark" as const }] : []),
+      ...(seiProject?.lifecycle ? [{ text: seiProject.lifecycle, variant: "dark" as const }] : []),
     ]}
     heading="Measure the Energy Intensity of"
     headingAccent="Your Software"
@@ -211,9 +211,9 @@ const carouselArticles = (await getCollection("articles", (a) => a.data.publishe
   <TeamGrid
     heading="Project *Leadership*"
     body={parentWg ? `Part of the ${parentWg.name}` : ""}
-    columns={seeProject?.leads?.length === 2 ? 2 : 3}
+    columns={seiProject?.leads?.length === 2 ? 2 : 3}
     highlighted={[]}
-    members={(seeProject?.leads ?? []).map(lead => ({
+    members={(seiProject?.leads ?? []).map(lead => ({
       fullName: lead.fullName,
       role: lead.roleLabel,
     }))}


### PR DESCRIPTION
## Summary

- SEI was missing from the "Current Standards & Projects" grid on `/standards/`, and the dedicated `/standards/sei/` page was rendering with no lifecycle badge, no parent working group, and no project leadership.
- Root cause: both pages looked up the project via `projects.find(p => p.slug === "see")`, but the SEI project's `slug` field in Notion's PWCIs database is actually `"sei"` (confirmed by querying the live database directly). The mismatch meant the lookup always returned `undefined`, silently dropping SEI from the grid.
- Fixed both lookups to match on `"sei"`, and updated the SEI page's article-carousel tag filter from `"see"` to `"sei"` for consistency with how other standards pages tag their articles (e.g. `"sci"`, `"rtc"`).

## Test plan

- [x] Ran a local `astro build` with representative `projects.json` data (slug `"sei"`, lifecycle `"Pre-draft"`, parent `"Software Standards Working Group"`) and confirmed the built `/standards/` page now includes the SEI card with its lifecycle badge, and `/standards/sei/` renders the hero badge and parent working group correctly.
- [ ] Confirm on the next Netlify deploy (which fetches live Notion data) that the SEI card appears in production.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUh2fadBDtemCmpWZAuvL7)_