### PR TITLE
Add SILO project Q&A page and hero CTA button

### DIFF
--- a/docs/pages/standards.md
+++ b/docs/pages/standards.md
@@ -70,14 +70,15 @@ Currently three hardware standards have dedicated pages:
 
 All three appear under the Hardware section in the nav (`src/lib/nav-items.ts`, SILO listed first) and in the standards index (`src/pages/standards/index.astro`, `standardDefs` array). Open19 and SILO both reuse WDPC's icon/illustration assets as placeholders — dedicated SVGs should be added to `public/assets/standards/open19/` and `public/assets/standards/silo/` once available. Articles tagged `"open19"` / `"silo"` will automatically appear in each page's carousel.
 
-### SILO hero CTAs — White Paper and Companion Technical Note
+### SILO hero CTAs — White Paper, Companion Technical Note, and Project Q&A
 
-The SILO page's hero `ctas` array (`src/pages/standards/silo/index.astro`) includes two links alongside "Visit the Directory" / "Back to Standards":
+The SILO page's hero `ctas` array (`src/pages/standards/silo/index.astro`) includes three links alongside "Visit the Directory" / "Back to Standards":
 
 - **White Paper** — links out to the SILO white paper on GitHub (`SILO_WHITEPAPER` const at the top of the page frontmatter).
 - **Companion Technical Note** — links to the internal companion note detailing the internal interoperability layer, published as a [research collection entry](research.md) at `/policy/research/silo-companion-technical-note/` (`SILO_COMPANION_NOTE` const).
+- **Project Q&A** — links to a Q&A covering the problem SILO solves, its audience, roadmap, and how to get involved, published as a [research collection entry](research.md) at `/policy/research/silo-project-qa/` (`SILO_PROJECT_QA` const).
 
-To update either link, edit the corresponding `const` at the top of `src/pages/standards/silo/index.astro` and its entry in the `ctas` array passed to `<Hero />`.
+To update any of these links, edit the corresponding `const` at the top of `src/pages/standards/silo/index.astro` and its entry in the `ctas` array passed to `<Hero />`.
 
 ## Lifecycle Stages
 

--- a/src/content/research/en/silo-project-qa.md
+++ b/src/content/research/en/silo-project-qa.md
@@ -1,0 +1,39 @@
+---
+title: "SILO Project Q&A"
+date: 2026-08-03
+published: true
+status: published
+type: report
+summary: >
+  Answers to common questions about the SILO project — the problem it solves in practice, who it's for, the roadmap ahead, and how to get involved.
+workingGroup: silo
+tags: ["silo", "hardware-standards"]
+---
+
+## Building on the problem SILO solves, can you share a scenario of how that would work in practice?
+
+In a typical AI data center, servers, CDUs, cooling systems, power distribution units, building management systems, and energy management software often come from different vendors. Each exposes telemetry in a different format, making it difficult to correlate data and automate system-wide optimization.
+
+With SILO, these systems will continue using their existing protocols, but their data will be translated into a common semantic model. Software will then be able to consume consistent information regardless of the underlying vendor or interface. This will enable coordinated optimization of compute, cooling, and power, allowing workload schedulers to make infrastructure-aware decisions, predictive control algorithms to optimize energy consumption, and operators to deploy new applications without developing custom integrations for every deployment.
+
+Ultimately, SILO will reduce integration complexity while enabling smarter, more energy-efficient operation of AI and high-performance computing infrastructure.
+
+## Who is SILO for and how can these audiences benefit from the project?
+
+SILO is intended for the entire data center ecosystem. This includes infrastructure equipment manufacturers, software platform providers, cloud operators, Hyperscalers, enterprise data center operators and systems integrators.
+
+For equipment vendors, SILO provides a common way to expose operational data without requiring proprietary integrations. For software developers, it offers a consistent interface to infrastructure telemetry, enabling applications to work across multi-vendor environments. For operators, it simplifies deployment across multi-vendor environments and unlocks new opportunities for optimizing energy efficiency and operational costs, while also improving reliability and supporting broader sustainability goals.
+
+## What's the roadmap of the project over the coming months?
+
+Over the coming months, we will finalize and publish both a white paper, describing the strategic vision, and a technical document defining the baseline specification. In parallel, we will recruit stakeholders from across the GSF community, industry, and academia to help shape the specification and ensure it addresses real-world interoperability challenges.
+
+The baseline specification will then be circulated for working group review, followed by a public review period to gather broader community feedback. As the specification matures, we plan to publish a dedicated GSF project page, submit a Committee Draft, and ultimately pursue ISO standardization, following the path of other successful GSF specifications.
+
+## How could a member get involved, and what expertise would be most useful to support the project's development?
+
+We welcome participation from anyone interested in improving interoperability across data center infrastructure.
+
+The most valuable contributions come from expertise in core data center domains: cooling, power, networking, storage, server management and telemetry, as well as familiarity with software platforms, digital twins, workload orchestration, and existing standards such as Redfish, SNIA, DMTF, and OpenTelemetry.
+
+Members can contribute by reviewing the specification, identifying interoperability challenges, proposing semantic models, validating use cases, and helping ensure that SILO addresses real operational needs across different segments of the industry.

--- a/src/pages/standards/silo/index.astro
+++ b/src/pages/standards/silo/index.astro
@@ -43,6 +43,7 @@ const HARDWARE_WG = "https://github.com/Green-Software-Foundation/hardware-stand
 const MEMBERSHIP_CTA = "/membership/";
 const SILO_WHITEPAPER = "https://github.com/Green-Software-Foundation/sci-policy-and-legislation-alignment-white-paper-series/blob/main/whitepapers/Interoperability%20Layer%20for%20Real-Time%20Data%20Centre%20Sustainability%20Optimisation.md";
 const SILO_COMPANION_NOTE = "/policy/research/silo-companion-technical-note/";
+const SILO_PROJECT_QA = "/policy/research/silo-project-qa/";
 ---
 
 <Layout
@@ -79,6 +80,7 @@ const SILO_COMPANION_NOTE = "/policy/research/silo-companion-technical-note/";
       { text: "Back to Standards", variant: "outline", href: "/standards/" },
       { text: "White Paper", variant: "outline", href: SILO_WHITEPAPER },
       { text: "Companion Technical Note", variant: "outline", href: SILO_COMPANION_NOTE },
+      { text: "Project Q&A", variant: "outline", href: SILO_PROJECT_QA },
     ]}
     imageSrc="/assets/standards/wdpc/hero-illustration.svg"
     imageAlt="SILO illustration"


### PR DESCRIPTION
Adds a Q&A research entry covering the problem SILO solves, its audience, roadmap, and how to get involved, and links to it from a new "Project Q&A" button on the SILO standards page hero, alongside the existing directory/paper/companion-note links.